### PR TITLE
updated to v0.2.6 - color unifies, form field fix & not showed diagnostics

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -1,3 +1,49 @@
+updated to v0.2.6 - color unifies, removed displayed diagnostics & fixes for form use 
+
+* v0.2.6 -- [2017-12-07]
+
+[*] MODIFIED
+
+-- index.php
+* changed few texts inside header and footer
+
+-- styl.css
+* unified background colors of a header's elements
+* background colors for main areas also unified
+  - changes near button next-page-loader
+* changed colors of a few headers
+  - slighty modified hover state or depending from theirs placing
+* expanded the size of buttons in header and footer
+
+-- witryna.js
+* loaded contents treated as html fragments not like regular text
+  - better works with further styling
+  - for some elements it's safer when their content is a text 
+
+[F] FIXED
+
+-- styl.css
+* proper displaying of loaded contents in gallery table of contents
+  - no more unintentional shift of content from the left (padding or margin)
+
+-- witryna.js
+* fixed loading contents for a gallery by form field
+  - derived from v0.1.1a
+  - moved logic inside a callback function
+  - proper handling of form data like a regular click from gallery lists
+  - handled equally within the same callback function for the form button click or gallery item click 
+
+[-] REMOVED 
+
+-- index.php
+* removed text header just before place where gallery details will be displayed as a first time
+
+-- styl.css
+* visually removed containers for displaying diagnostics for encountered elements of gallery table of contents and actual subpage
+* also removed yellow belt containing counter of encountered subpages of currently displayed gallery
+
+---------------------------
+
 updated to v0.2.5 - external JavaScript, page header, new pics, animating logo
 
 * v0.2.5 -- [2017-11-20]

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@
   <div id="naglowek_kontener">
 			
    <h1 class="zmienny">Do uruchomienia galerii wymagane podanie adresu witryny ze zdjęciami <button id="odswiez" style="margin: 0.05em; padding: 0.1em 0.6em; font-size: 60%;">Odśwież</button></h1>
-			<h3>Umożliwia łatwiejszy podgląd rozrabiajacych wnuków przez dziadków. Wpisz/wklej pełny adres do przeglądania galerii z witryny <a class="odnosnik_czerwony" href="http://zlobek.chojnow.eu/" target="_blank">zlobek.chojnow.eu</a> lub skorzystaj z poniższej listy galerii</h3>
+			<h3>Wpisz/wklej pełny adres do przeglądania galerii z witryny <a class="odnosnik_czerwony" href="http://zlobek.chojnow.eu/" target="_blank">zlobek.chojnow.eu</a> lub po prostu skorzystaj z poniższej listy galerii</h3>
    <div id="formularz">
     <form action="#" method="post" id="wyszukaj">
 				 <fieldset>
@@ -69,7 +69,7 @@
 
  <div id="glowna">
 			<div id="komentarz">
-			<h2>A poniżej może pojawią się zdjęcia wnuków, o ile podamy dobry adres i reszta zadziała prawidłowo...</h2>
+			<!--<h2>A poniżej może pojawią się zdjęcia wnuków, o ile podamy dobry adres i reszta zadziała prawidłowo...</h2>-->
 			</div>
 			
 		<div id="nazwa_galerii">
@@ -92,13 +92,13 @@
 		
 	</div>
 
-	<footer id="stopka">&copy;2017 v0.2.5 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
+	<footer id="stopka">&copy;2017 v0.2.6 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
 	
 	 <div id="poco">
 	  <h3>Jaki jest cel?</h3>
 	   <p>Ta strona odpowiada żywotnym potrzebom całego społeczeństwa. To jest witryna na skalę naszych możliwości. Ty wiesz, co my robimy tym serwisem? My otwieramy oczy niedowiarkom. Patrzcie, to nasze, przez nas wykonane i to nie jest nasze ostatnie słowo.</p>
 	  <h3>Po polskiemu</h3>
-	   <p>Galerię żłobka przeglądało się karygodnie, więc należało coś z tym zrobić. Obsługa tego serwisu również jest toporna, ale miejmy nadzieję, że z czasem zapewni ona łatwe funkcjonowanie. Kiedy powstanie optymalny interefejs obecnie wymagane kopiowanie odnośników nie będzie koniecznością, a jedynie prostym działaniem (no może jeszcze nie przyjemnością). </p>
+	   <p>Galerię żłobka przeglądało się karygodnie, więc należało coś z tym zrobić. Wcześniejsza obsługa tego serwisu również była mało intuicyjna, ale z czasem zapewniono (w miarę) łatwe nawigowanie pomiędzy kolejnymi zdjęciami w ramach wielu galerii. Bieżący wygląd interefejsu stanowi niemal końcową funkcjonalność witryny. Dla testów i zauważalności postępów nad intuicyjnością interejsu zachowano relikt z formularzem i koniecznością kopiowania odnośników.</p>
 	  <h3>Jeszcze raz</h3>
 	  <p>Poniższa witryna ma za zadanie tylko ułatwić korzytanie z materiałów zawartych w serwisie żłobka. Twórcy zależy na przedłużeniu życia myszy oraz powierzchni dotykowych komputerów, dlatego jego celem jest przeniesienie obciążenia na klawisze strzałek oraz w przyszłości na ewentulane kółko myszy (funkcjonalność zależna od dostawcy usług, a w zasadzie wyboru innego dostawcy).     
 	  <h3>Informacje i zastrzeżenia</h3>
@@ -108,7 +108,7 @@
   <h3>Witryna wymaga dostępu do lokalizacji, skąd pochodzą oryginalne materiały.</h3>
  	 <p>Niniejszy serwis służy tylko do łatwiejszego wyświetlania galerii z osobami skazanymi na pobyt w żłobku. Bezwzględnie jest wymagany dostęp do oryginalnego serwisu.</p>
  	<h3>Kopiuj-wklej</h3>
- 	 <p>Bieżący serwis wymaga podania działającego odnośnika do serwisu zlobek.chojnow.eu, konkretnie do jednej z wielu galerii. Odnośnik z paska adresu należy wpisać (wkleić) w pole formularza. Prawdopodobnie ten mechanizm jest nieco utrudniony przy posługiowaniu się przeglądarką mobilną, korzytając z telefonu (smartfonu). Dowolna przeglądarka www z komputera zapewnia machanizm kopiowania.  
+ 	 <p>Pierwotna funkcjonalnośc wymagała podania działającego odnośnika do serwisu zlobek.chojnow.eu, konkretnie do jednej z wielu galerii. Wiązało się to z koniecznością przekazania adresu, po uprzednim odwiedzeniu witryny żłobka i skopiowania zawartości z paska adresu. Teraz wklajanie w pole formularza nie jest wymagane i prawodpodobnie ta uprzykrzająca funkcjonalnośc zostanie wkrótce usunięta.
  	<h3>Podstrony</h3>
   	<p>Przeglądanie w galeriach ograniczających klikanie działa prawiłowo dla maksymalnie osiemnastu obrazków w galerii. Serwis ma umożliwić łatwą nawigację pomiędzy kolejnymi obrazkami.</p>
   <h3>Uwaga</h3> 

--- a/styl.css
+++ b/styl.css
@@ -43,7 +43,9 @@ position: relative;
 header#naglowek div#logo {
 position: relative;	
 /*float: left;	*/
-background-color: rgba(85, 85, 185, 0.3);
+
+	background-color: cornflowerblue;	
+	/*background-color: rgba(85, 85, 185, 0.3); */
 height: 200px;
 width: 200px;	
 
@@ -64,7 +66,7 @@ position: absolute;
 left: -115px;
 top: -115px;	
 	
-outline: 2px solid red;
+/* outline: 2px solid red; */
 	
 transform-origin: 50% 50%;
 
@@ -90,7 +92,9 @@ header#naglowek div#napisy {
 position: absolute;
 left: 200px;
 top: 0;	
-background-color: rgba(95, 95, 225, 0.7);	
+		
+		background-color: cornflowerblue;	
+		/* background-color: rgba(95, 95, 225, 0.7); */	
 }
 
 header#naglowek div#napisy p {
@@ -105,7 +109,7 @@ clear: both;
 header#naglowek a.odnosnik_czerwony {
 font-size : 120% ;
 font-weight : bold ;
-color : #e22	;
+color : #d46	;
 text-decoration :	underline;	
 }
 
@@ -179,8 +183,8 @@ div#spis_tresci div#galeria_spis {
 background-color: cornflowerblue;
 /* float: left;	*/
 padding: 1em;	
-margin-left: 1em;
-margin-right: 1em;	
+/*margin-left: 1em;
+margin-right: 1em;	*/
 margin-bottom: 1em;	
 overflow: hidden;
 width: 100%;	
@@ -195,7 +199,7 @@ border-radius: 5px;
 width : 100%	;
 float: left;
 max-width: 250px;	
-transition: background-color 0.25s ease-out;	
+transition: all 0.25s ease-out;	
 min-height: 575px;			
 max-height: 575px;
 overflow: hidden;
@@ -300,7 +304,7 @@ max-height: 96px;
 
 
 div#spis_tresci div#spis_sterowanie {
-background-color: aqua;	
+		/* background-color: aqua;	*/
 
 }
 
@@ -308,7 +312,8 @@ background-color: aqua;
 div#spis_sterowanie p#status_galerii_spis {
 padding: 0.6em 1em;
 border: 2px dashed blue;
-background-color: rgba(50, 60, 200, 0.7);	
+background-color: rgba(50, 60, 200, 0.7);
+			display: none; 	
 }
 
 
@@ -341,6 +346,7 @@ float : right ;
 padding : 1em ;	
 margin : 1em ;
 border : 2px solid red ;	
+			display: none /*  --- */	
 }
 
 
@@ -419,7 +425,7 @@ top: 185px ;
 left: 1150px ;
 background-color: yellow ;
 border: 2px solid red ;	
-  /* display: none ; */
+   display: none ; /* --- */
 }
 
 
@@ -476,7 +482,8 @@ box-shadow: 2px 2px 5px rgba(0,0,0, 0.7);
 
 footer#stopka button {
 font-size: 120%;
-padding: 0.1em 1em;	
+margin-left: 0.5em;	
+padding: 0.35em 2em;	
 }
 
 footer#stopka div#poco {
@@ -518,7 +525,7 @@ text-align: center;
 
 h1.zmienny:hover {
 margin-left: 30px;
-color: mediumblue;
+color: #ee6699;
 text-shadow: 1px 1px 1px #eee, 3px 3px 8px #444, 1px 1px 4px #222;
 }
 
@@ -529,7 +536,7 @@ h2 {
 font-size: 175%;
 font-weight: bold;
 /* color: darkred; */
-color: #54f;
+color: #54c;
 padding: 0.2em 0.5em;	
 text-shadow: 2px 2px 6px #666;
 text-align: center;	
@@ -546,7 +553,7 @@ h3 {
 font-size: 125%;
 font-weight: bold;
 color: darkmagenta;
-text-shadow: 1px 1px 3px #bbb;
+text-shadow: 1px 1px 3px #ccc;
 padding: 0.2em 0.5em;	
 text-align: center;	
 }

--- a/witryna.js
+++ b/witryna.js
@@ -101,8 +101,8 @@ $('#wczytywanie').hide(100);	// schowaj informację, skoro wczytano zawartość
 $('#glowna div:first').hide(100);	//showaj opis-informację
 $('#skladowisko').show(100);	// pokaż kontener na zaczytaną zawartość
 
-$('#nazwa_galerii').find('h2').text( g_nazwa_galerii );
-$('#nazwa_galerii').find('p').text( g_opis_galerii );	
+$('#nazwa_galerii').find('h2').html( g_nazwa_galerii ); 	// było.text( ... )
+$('#nazwa_galerii').find('p').html( g_opis_galerii );		// było.text( ... )
 $('#nazwa_galerii').show(100);	
 
 	
@@ -321,13 +321,19 @@ var $odnosniki_data = $( g_tag_do_podmiany_spis + " td.galeria_kolor font" );
 	{
 			for( var i=0 ; i < $odnosniki_data.length ; i++ ){
 			miejsce_docelowe = $( g_miejsce_na_spis + " .data_odnosnik:eq(" + ( g_ilosc_zaczytanych_galerii + i ) + ")" );
-				
+
 			// ... 			// obrabianie odnośnika?!
 			var tekst_docelowy = $( $odnosniki_data[i] ).text();
-			tekst_docelowy = tekst_docelowy.replace( "data publikacji: ", "z dnia: ");	
-			$( $odnosniki_data[i] ).text( tekst_docelowy ).removeAttr("style");
 				
-			$( miejsce_docelowe ).html( $odnosniki_data[i] );
+			tekst_docelowy = tekst_docelowy.replace( "data publikacji: ", "z dnia: ");
+			//tekst_docelowy = tekst_docelowy.replace('<font>', '' );
+			//tekst_docelowy = tekst_docelowy.replace('</font>', '' );
+				
+			// poniższe niepotrzebne, tylko kilka liter -- nie ma potrzeby kopiować znacznika	
+			//$( $odnosniki_data[i] ).text( tekst_docelowy ).removeAttr("style");
+			//$( miejsce_docelowe ).html( $odnosniki_data[i] );
+				
+			$( miejsce_docelowe ).text( 	tekst_docelowy );	
 		}
 	}
 	
@@ -709,12 +715,12 @@ var galeria_docelowa = $this.attr('href');
 
 e.preventDefault();	// "nieprzechodzeniedalej" po odnośnku
 	
-g_nazwa_galerii = $this.text();	  // przypisanie treści -- tytułu dla danej galerii (wstępnie, jeśli naciśnięto na nagłówek a nie obrazek)
-g_opis_galerii = $this.parents('.kontener_odnosnik').find('.opis_odnosnik').text();	
+g_nazwa_galerii = $this.text();	  // przypisanie treści -- tytułu dla danej galerii (wstępnie, jeśli naciśnięto na nagłówek a nie obrazek)   
+g_opis_galerii = $this.parents('.kontener_odnosnik').find('.opis_odnosnik').html();	 // było .text( ... )
 	
 	if ( g_nazwa_galerii.length == 0 )  // jeżeli naciśnięto odnośnik z obrazkiem, ten drugi zawiera już treść odnośnika
 		{
-		g_nazwa_galerii = $this.parent().siblings('div.tytul_odnosnik').find('a h2').text();	
+		g_nazwa_galerii = $this.parent().siblings('div.tytul_odnosnik').find('a h2').html();	 // było .text( ... )
 		}
 //alert('g_tag_do_podmiany, g_protokol_www + g_adres_strony + '/' + g_folder_serwera + '/', galeria_docelowa, g_element_zewnetrzny, "galeria_podstrona")
 //alert('WczytajZewnetrznyHTMLdoTAGU( tag: ' + g_tag_do_podmiany_zdjecia + ', domena: ' + g_protokol_www + g_adres_strony + '/' + g_folder_serwera + '/' + ', zasób: ' + galeria_docelowa + ', elem: ' + g_element_zewnetrzny + ') ... MYSZA NAJECHAŁA');
@@ -782,7 +788,7 @@ pelny_adres_wpisany = pelny_adres_wpisany.stripHTML(); // czyszczenie z formular
 	
 	var adres_tej_galerii = pelny_adres_wpisany.substr( pelny_adres.lastIndexOf('/') + 1 ); // szukanie podciągu od "/ do adresu_zasobu.html" 
 
-	 alert('pełny_adres: "' + pelny_adres + '", adres_tej_galerii: "' + adres_tej_galerii + '"');
+	//alert('pełny_adres: "' + pelny_adres + '", adres_tej_galerii: "' + adres_tej_galerii + '"');
 	//$('#http_adres').val( g_adres_strony + adres_tej_galerii );
  $('#http_adres').val( pelny_adres + adres_tej_galerii );	
 	$('#http_adres').prop("disabled", true); 								// wyłączenie, aby nie klikac wielokrotnie || attr() vs prop()
@@ -807,7 +813,7 @@ cała galeria siedzi w tabeli o klasie .galeria, w komórkach osadzone miniatury
 	
 // to poniżej powinno działać tylo dla tej samej domeny/lokalizacji co skrypt, wiec porażka 
 
-WczytajZewnetrznyHTMLdoTAGU( g_tag_do_podmiany_zdjecia, g_adres_strony, adres_tej_galerii, g_element_zewnetrzny, "galeria_podstrona" ); 
+WczytajZewnetrznyHTMLdoTAGU( g_tag_do_podmiany_zdjecia, g_protokol_www + g_adres_strony + '/', adres_tej_galerii, g_element_zewnetrzny, "galeria_podstrona" ); 
 
 	/* 
 $('div#zawartosc_do_podmiany').load( g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + pelny_adres + g_element_zewnetrzny, function() {


### PR DESCRIPTION
**updated to v0.2.6 - color unifies, removed displayed diagnostics & fixes for form use**

(a better candidate for being a pro)

* v0.2.6 -- [2017-12-07]

[*] MODIFIED

-- index.php
* changed few texts inside header and footer

-- styl.css
* unified background colors of a header's elements
* background colors for main areas also unified
  - changes near button next-page-loader
* changed colors of a few headers
  - slighty modified hover state or depending from theirs placing
* expanded the size of buttons in header and footer

-- witryna.js
* loaded contents treated as html fragments not like regular text
  - better works with further styling
  - for some elements it's safer when their content is a text

[F] FIXED

-- styl.css
* proper displaying of loaded contents in gallery table of contents
  - no more unintentional shift of content from the left (padding or margin)

-- witryna.js
* fixed loading contents for a gallery by form field
  - derived from v0.1.1a
  - moved logic inside a callback function
  - proper handling of form data like a regular click from gallery lists
  - handled equally within the same callback function for the form button click or gallery item click

[-] REMOVED

-- index.php
* removed text header just before place where gallery details will be displayed as a first time

-- styl.css
* visually removed containers for displaying diagnostics for encountered elements of gallery table of contents and actual subpage
* also removed yellow belt containing counter of encountered subpages of currently displayed gallery