### PR TITLE
updated to v0.2.7 - rebuild of header, site title distinguishion, fit…

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -1,3 +1,39 @@
+updated to v0.2.7 - rebuild of header, site title distinguishion, fittext 
+
+* v0.2.7 -- [2018-03-03]
+
+[+] ADDED
+
+-- new folder 'fittext'
+
+-- new file 'fittext/jquery.fittext.js'
+* enables text scaling depending on parent element size
+  - screen size as a delimiter
+  - to reducing the size of a text trather than an enlarge 
+* added styles for new structure of header with logo
+
+[*] MODIFIED
+
+-- index.php
+* rebuild structure of page header
+
+-- styl.css
+* increased site name's distinctiveness (logo text)
+  - significantly font text increased
+
+-- witryna.js
+* added ability reduce of text of logo and under the logo
+  - configured size of the logo texts for 'fittext' addon
+* added logic in ajax handler depending of success or failure (WczytajZewnetrznyHTMLdoTAGU)
+- differentiator inside each switch statement
+- errors logged into console if encounters any are described with detailed status
+
+[!] BUG
+-- index.php
+* logo texts size is decreasing when page shrinks but remains the same and not grows when page width increases
+
+---------------------------
+
 updated to v0.2.6 - color unifies, removed displayed diagnostics & fixes for form use 
 
 * v0.2.6 -- [2017-12-07]

--- a/fittext/jquery.fittext.js
+++ b/fittext/jquery.fittext.js
@@ -1,0 +1,43 @@
+/*global jQuery */
+/*!
+* FitText.js 1.2
+*
+* Copyright 2011, Dave Rupert http://daverupert.com
+* Released under the WTFPL license
+* http://sam.zoy.org/wtfpl/
+*
+* Date: Thu May 05 14:23:00 2011 -0600
+*/
+
+(function( $ ){
+
+  $.fn.fitText = function( kompressor, options ) {
+
+    // Setup options
+    var compressor = kompressor || 1,
+        settings = $.extend({
+          'minFontSize' : Number.NEGATIVE_INFINITY,
+          'maxFontSize' : Number.POSITIVE_INFINITY
+        }, options);
+
+    return this.each(function(){
+
+      // Store the object
+      var $this = $(this);
+
+      // Resizer() resizes items based on the object width divided by the compressor * 10
+      var resizer = function () {
+        $this.css('font-size', Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
+      };
+
+      // Call once to set.
+      resizer();
+
+      // Call on resize. Opera debounces their resize by default.
+      $(window).on('resize.fittext orientationchange.fittext', resizer);
+
+    });
+
+  };
+
+})( jQuery );

--- a/index.php
+++ b/index.php
@@ -11,6 +11,7 @@
 
         <script src="jquery-3.2.1.js"></script>
         <script src="lightbox/js/lightbox.js"></script>
+		<script src="fittext/jquery.fittext.js"></script>	
 		<script src="witryna.js"></script>
 
 	</head>
@@ -26,10 +27,15 @@
 			<div id="slonce_logo"><!-- <img src="grafiki/slonce.png"> --></div>
 		</div>
 		<div id="napisy">
-			<h1><span>Zobacz Wnuka!</span> Galeria ze <span>Żłobka Słoneczko</span> w Chojnowie</h1>
- 		<h3>Serwis umożliwia łatwiejszy podgląd rozrabiajacych wnuków przez dziadków ... i nie tylko. Treści pochodzą z witryny <a class="odnosnik_czerwony" href="http://zlobek.chojnow.eu/" target="_blank">zlobek.chojnow.eu</a></h3>
+			<h1 class="logo">Zobacz Wnuka!</h1>
+			<h2 class="logo">Galeria ze <span>Żłobka Słoneczko</span> w Chojnowie</h2>
  		<p class="clearfix2" />
+ 	
 		</div>
+		<div id="napis_spod">
+			<h3>Serwis umożliwia łatwiejszy podgląd rozrabiajacych wnuków przez dziadków ... i nie tylko. Treści pochodzą z witryny <a class="odnosnik_czerwony" href="http://zlobek.chojnow.eu/" target="_blank">zlobek.chojnow.eu</a></h3>
+		</div>
+
 	</div>
 	
   <div id="naglowek_kontener">
@@ -92,7 +98,7 @@
 		
 	</div>
 
-	<footer id="stopka">&copy;2017 v0.2.6 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
+	<footer id="stopka">&copy;2017 v0.2.7 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
 	
 	 <div id="poco">
 	  <h3>Jaki jest cel?</h3>

--- a/styl.css
+++ b/styl.css
@@ -18,6 +18,25 @@ color: yellow;
 font-weight: bolder;
 }
 
+header#naglowek h2 span {
+color: yellow;
+font-weight: bolder;
+}
+
+header#naglowek div#napis_spod {
+position:absolute;
+left: 0;
+bottom: 0;
+background-color: rgba(100,100, 200, 0.7);
+width: 100%;	
+}
+
+div#napis_spod h3 {
+width: 100%;	
+max-height: 26px;	
+	
+}
+
 
 header#naglowek div#banner {
 border-top-left-radius: 10px;
@@ -529,6 +548,12 @@ color: #ee6699;
 text-shadow: 1px 1px 1px #eee, 3px 3px 8px #444, 1px 1px 4px #222;
 }
 
+h1.logo {
+color: yellow;
+font-size: 300%;
+padding-bottom: 0.05em;	
+}
+
 
 
 
@@ -544,7 +569,12 @@ text-align: center;
 
 h2.przycisk {
 background-color: dodgerblue;
+}
 
+h2.logo {
+font-size: 225%;	
+padding-top: 0;
+line-height: 20px;	
 }
 
 

--- a/witryna.js
+++ b/witryna.js
@@ -49,14 +49,19 @@ function WczytajZewnetrznyHTMLdoTAGU ( tag_podmieniany, adres_domeny, adres_zaso
 	 switch ( rodzaj_dzialania ) {
 				
 			case "galeria_podstrona":
-				$(tag_podmieniany).load( g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + adres_domeny + adres_zasobu + element_witryny, function() {
-					// alert( "LOAD się udała dla zapytania\n" + g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + pelny_adres + g_element_zewnetrzny );
+				$(tag_podmieniany).load( g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + adres_domeny + adres_zasobu + element_witryny, function(odpowiedz, status, xhr) {
+					if ( status === "success" )// alert( "LOAD się udała dla zapytania\n" + g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + pelny_adres + g_element_zewnetrzny );
+					{	
 					// logowanie sukcesu ;)
 					console.log( "wykonano load(" + rodzaj_dzialania + ") dla elementu '" + tag_podmieniany + "' dla zapytania \'" + g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + adres_domeny + adres_zasobu + element_witryny +"\'");
 					// WYKONAJ DALSZE FUNKCJE, zależne od SUKCESU zaczytania lub nie	
 					// kasuj poprzednią zawartość elementu???	
 
 					GenerujPodstronyGalerii();
+					}
+					else{
+					alert("Coś się zwaliło przy PODSTRONIE galerii! STATUS: " + status + " , XHR: " + xhr.status + " (" + xhr.statusText + ")" );	
+					}
 					}); //load-END
 				
 				break;
@@ -64,7 +69,9 @@ function WczytajZewnetrznyHTMLdoTAGU ( tag_podmieniany, adres_domeny, adres_zaso
 					
 			case "spis_galerii" :
 				
-				$(tag_podmieniany).load( g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + adres_domeny + adres_zasobu + element_witryny, function() {
+				$(tag_podmieniany).load( g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + adres_domeny + adres_zasobu + element_witryny, function(odpowiedz, status, xhr) {
+					if ( status === "success" )
+					{	
 					// alert( "LOAD się udała dla zapytania\n" + g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + pelny_adres + g_element_zewnetrzny );
 					// logowanie sukcesu ;)
 					console.log( "wykonano load(" + rodzaj_dzialania + ") dla elementu '" + tag_podmieniany + "' dla zapytania \'" + g_przechwytywacz_php + g_przechwytywacz_php_zapytanie + adres_domeny + adres_zasobu + element_witryny +"\'");
@@ -72,8 +79,12 @@ function WczytajZewnetrznyHTMLdoTAGU ( tag_podmieniany, adres_domeny, adres_zaso
 					//$(tag_podmieniany).html( unescape(encodeURIComponent(podmieniona_zawartosc)) );	// jednao z wielu mozliwych zamian kodowania
 					
 				// ... // przetwarzanie spisu treści
-				GenerujSpisGalerii();
-				
+				 GenerujSpisGalerii();
+					}
+					else
+					{	
+					alert("Coś się zwaliło przy SPISIE galerii! STATUS: " + status + " , XHR: " + xhr.status + " (" + xhr.statusText + ")");					
+					}
 					
 				}); // load-END
 
@@ -614,8 +625,12 @@ ZaczytajSpisGalerii();
 
 	
 
-	// ...	
+	// sterowanie wielkością czcionki nagłówka
 	
+	//$("#banner h1.logo").fitText();
+	 $("#napisy h1").fitText(1.0, { minFontSize: '15px', maxFontSize: '65px' });
+	 $("#napisy h2").fitText(2.7, { minFontSize: '10px', maxFontSize: '28px' });
+	 $("#napis_spod h3").fitText(3.0, { minFontSize: '6px', maxFontSize: '20px' });
 	
 	
 // ---------- *** FUNKCJE ZDARZENIOWE *** --------------	


### PR DESCRIPTION
…text

* v0.2.7 -- [2018-03-03]

[+] ADDED

-- new folder 'fittext'

-- new file 'fittext/jquery.fittext.js'
* enables text scaling depending on parent element size
  - screen size as a delimiter
  - to reducing the size of a text trather than an enlarge
* added styles for new structure of header with logo

[*] MODIFIED

-- index.php
* rebuilded structure of page header

-- styl.css
* increased site name's distinctiveness (logo text)
  - significantly font text increased

-- witryna.js
* added ability reduce of text of logo and under the logo
  - configured size of the logo texts for 'fittext' addon
* added logic in ajax handler depending of success or failure (WczytajZewnetrznyHTMLdoTAGU)
- differentiator inside each switch statement
- errors logged into console if encounters any are described with detailed status

[!] BUG
-- index.php
* logo texts size is decreasing when page shrinks but remains the same and not grows when page width increases