### PR TITLE
0.4 lame pro

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -1,3 +1,55 @@
+v0.4.19 - loading notification moved up, text before subgallery nav, buttons labelled 'subgallery'; CSS: generic first, cleanings, comment-headers, hand icon for selective forms bar; F: removed white border of sliders in FF;
+
+* v0.4.19 -- [2018-08-23]
+
+[*] MODIFIED
+
+-- index.php
+* moved up notification of loading of next gallery subpage, an element with id of 'wczytywanie_spis'
+  - placed before a button of loading next subpage
+  - so it's before when selected subpage gallery list is visible also
+* for test purpose changed label text of increment/decrement buttons
+  - using another symbols of arrows due to problems with displaing some of 'triangle arrows' on some old browsers
+* added another attribute to the object inside last block of 'script' tags
+  - used for global initialization fittext addon
+
+-- zlobek-styl.css
+
+* moved up definitions of generic styles for elements or classes
+  - the next selectors sometimes redefines this already defined styles  by placing parent class or ids at the begining of their selectors  
+  - anything is added to generic and always increase specifity of selector
+* added a pointer icon to 'h2' of id 'selektor_naglowek' to easily differentiate possible action on this element
+  - also added separately icon for child 'span' element
+* CSS cleaning
+  - completely removed from file, already commented rules, 'mobile-last' with 'max-width' values instead 'min-width'
+  - removed unnecessary new lines
+* added comment lines with names as separators for grouped content
+  - it groups many selectors by similar topics or areas of the page
+  - each semantic group contents is easier to find
+  - it was done before and intentionally, there wasn't only a named  descriptions for groups
+  - also added new comments as a subgroups or headers, to easier distiguish any content of CSS 
+
+-- witryna.js
+* little changes inside function 'GenerujPodstronyGalerii'
+  - first any previous content of possible navigations are removed by 'empty()' method
+  - and secondly to empty container may be placed generic text, that informs about any subpage, only if any subpage of given gallery exists
+  - if so the button or buttons are placed under the previously generated text of header
+  - changed the label on the button form 'Gallery #No' to 'Subpage #No' 
+  - all the dynamic content is surronded by container class that limits the total width of its contents on larger screens
+
+[F] FIXED
+
+-- zlobek-style.css
+* removed white border  around the slider, which is in a focus state
+  - changed color of used outline to transparent inside vendor specified selector ':-moz-focusring '
+  - still in use 3px thin border around slider but it's invisible now
+  - couldn't change any internal behavior of thin black border, which is also dotted
+  - probably a usability thing that can't be styled by a programmer
+  - fixes: #21 - 'Firefox: a white box around the active form'
+  - modified also the color of outline itself to value of 'none' inside vendor specified selector ('::-moz-range-thumb') to stayed a center of slider handle in the same place when is hovered, focused or inactive
+
+---------------------------
+
 v0.4.18 - verified media queries for 4 gallery items in a line; touches CSS of sliders and draggable 'imgs'; cleaning of coding style of styles
 
 * v0.4.18 -- [2018-08-15]

--- a/_changelog.md
+++ b/_changelog.md
@@ -1,3 +1,34 @@
+v0.4.17 - modified headings & pagraphs texts of footer; and theirs padings also; computing of subgallery number; arrangement of current gallery details on wider screens;
+
+* v0.4.17 -- [2018-08-12]
+
+[*] MODIFIED
+
+-- index.php
+* changed texts of paragraphs of many paragraph and subheaders in footer area and in 'game area'
+  - extended for some longer sentences
+  - some of them were shortened
+  - used quotations, cites and brackets
+
+-- witryna.js
+* removed conditional statement inside function 'KtoraPodstronaWGalerii'
+  - now the same formula used to calculate subpage based by given gallery number
+  - probably a possible error in computations if total gallery number is divisible by 5!!!
+  - hard to test when last digit in number of lastly added gallery (total gallery number) isn't 0 or 5
+  - it's hard to test when gallery total number is read form another place and any substitution of it or simulations breaks loaded subpages numbers or the awaitet result (fault of grouping results in reverse order, which affects the numbering of each subpage)  
+
+-- zlobek-styl.css
+* increased paddings for current gallery details container, with id of 'nazwa_galerii'
+* increased left padding for current gallery description to visual align it in vertical axis with photo
+* modified recently builded layout inside current gallery details on wide screens
+  - moved into 940px treshold of media query from previously defined in 1180px
+  - slighty decreased images top margin to 2em from previously 2.5em 
+  - increased left padding  for a title element to 6.5em (previously it was 5em) 
+* increased by 10% font size for paragraphs inside footer
+* added extra bottom pading after a last paragraph inside footer
+
+---------------------------
+
 v0.4.16 - anims touched game-init-button; email address & its security; footer content reordered by little; greater buttons in game section
 
 * v0.4.16 -- [2018-08-07]

--- a/_changelog.md
+++ b/_changelog.md
@@ -1,3 +1,26 @@
+v0.4.18 - verified media queries for 4 gallery items in a line; touches CSS of sliders and draggable 'imgs'; cleaning of coding style of styles
+
+* v0.4.18 -- [2018-08-15]
+
+[*] MODIFIED
+
+-- zlobek-styl.css
+* verified the media query tresholds for proper displaying of given number of gallery list items
+  - tested why four items cannot be displayed in one line, when screen wides from about 500 to 1200px  
+  - above 700px wide the page shows three gallery items side by side
+  - above 940px is displayed a four gallery items in one row
+  - five elements when it's wider than 1180px
+* redefined global selector for any draggable ('[draggable]') element to a child and draggable 'img' element of container 'gra'
+* trying to create more compatible look the slider between main browsers
+  - experimented with paddings, margins and their values (negatives also)
+  - mainly to achieve similar look into Chrome
+  - slighty changes color of sliders, especially for extended IE style
+  - also modified in IE a separate hover and focus state for achieving three different sizes of the handle of the slider
+* slighty changes of padding inside footer by media queries
+* matched indentations to be equal or just similar inside the same selector, especially in defined media query
+
+---------------------------
+
 v0.4.17 - modified headings & pagraphs texts of footer; and theirs padings also; computing of subgallery number; arrangement of current gallery details on wider screens;
 
 * v0.4.17 -- [2018-08-12]
@@ -8,7 +31,7 @@ v0.4.17 - modified headings & pagraphs texts of footer; and theirs padings also;
 * changed texts of paragraphs of many paragraph and subheaders in footer area and in 'game area'
   - extended for some longer sentences
   - some of them were shortened
-  - used quotations, cites and brackets
+  - used quotations, cites and parentheses
 
 -- witryna.js
 * removed conditional statement inside function 'KtoraPodstronaWGalerii'

--- a/index.php
+++ b/index.php
@@ -241,7 +241,7 @@
         </div> <!--     <div id="gra">  -->
         
         
-        <footer id="stopka">&copy;2018 v0.4.17 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
+        <footer id="stopka">&copy;2018 v0.4.18 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
             <div id="poco">
                 <div class="kontener">
                     <h3>Dla Hani</h3>

--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@
         <header id="naglowek">
         <!-- <div class="kontener">  -->
 
-            <!-- tu </div> - kontener - tylko na nagłówek, tj. logo z animacjami (a nie całą zawartość zamnknąc w tych okowach... choć ideaklnie pasuje to ułatwienie  --> 
+            <!-- tu </div> - kontener - tylko na nagłówek, tj. logo z animacjami (a nie całą zawartość zamknąć w tych okowach... choć ideaklnie pasuje to ułatwienie  --> 
 
             <div id="naglowek_kontener">
 
@@ -77,6 +77,11 @@
                                 </div>
                             </div>    
                         </div>
+                        
+                        <div id="wczytywanie_spis">
+                            <h2>Trwa wczytywanie... <img src="grafiki/slonce_60x60.png" /></h2>
+                        </div>
+                        
                     </div>
                 
                     <div id="wybrany_zaczytany_spis">
@@ -103,11 +108,14 @@
                         </div>
                         <h2 id="zaladuj_galerie_spis" class="przycisk clearfix2">Załaduj kolejne galerie</h2>
 
-                        
+                        <!-- pierwotne położenie animacji wczytywania --> 
+                        <!-- 
                         <div id="wczytywanie_spis">
                         <h2>Trwa wczytywanie... <img src="grafiki/slonce_60x60.png" /></h2>
                         </div>
-
+                        -->
+                      
+                       
                         <div class="kontener">
                             <div id="selektor">     
                                 <h2 id="selektor_naglowek">...lub wybierz dowolną galerię poniżej <span>rozwiń ▼</span></h2>
@@ -125,8 +133,8 @@
                                             </div>
                                             <div id="suwak_info">
                                                 <div>
-                                                <input type="button" id="wybrany_nr_zmniejsz" class="maly_guzik" value="◄" />
-                                                <input type="button" id="wybrany_nr_zwieksz" class="maly_guzik" value="►" />
+                                                <input type="button" id="wybrany_nr_zmniejsz" class="maly_guzik" value="-1 ◄ &larr;" />
+                                                <input type="button" id="wybrany_nr_zwieksz" class="maly_guzik" value="+1 ► &rarr;" />
                                                 </div>
                                             </div>
                                             <div>
@@ -241,7 +249,7 @@
         </div> <!--     <div id="gra">  -->
         
         
-        <footer id="stopka">&copy;2018 v0.4.18 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
+        <footer id="stopka">&copy;2018 v0.4.19 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
             <div id="poco">
                 <div class="kontener">
                     <h3>Dla Hani</h3>
@@ -312,7 +320,9 @@
 		<script src="witryna.js"></script> 		
 		<script src="lightbox/js/lightbox.js"></script>
         <script>
-            lightbox.option({ albumLabel : "Zdjęcie %1 z %2"
+            lightbox.option({   albumLabel : "Zdjęcie %1 z %2", 
+                                positionFromTop : 10
+
             });
         </script>
 		

--- a/index.php
+++ b/index.php
@@ -217,9 +217,9 @@
             <div id="reguły">
                 <div class="kontener">    
                 <h1>Pokoloruj duży obrazek poprzez ułożenie małych obrazków we właściwych miejscach.</h1>
-                <h2>Użyj myszy lub gładzika komputera, bo małe ekrany dotykowe są be (póki co jest dramat)!</h2>
-                <p style="text-decoration: line-through;"><em>Podobne widowisko teatralne</em> jest z użyciem czegokolwiek na czymkolwiek do obsługi przeciągania, więc póki co zdobywanie punktów i budowanie rankingów jest odłożone w bliżej nieokreslone <em>kiedyś</em>.</p>   
-                <p style="text-decoration: line-through;">Rozgrywka jest na czas, spróbuj osiągnąć możliwie najlepszy wynik (zakładając, że system nie oszukuje przy przydziale punktów).</p>
+                <h2>Użyj myszy lub gładzika komputera, bo małe ekrany dotykowe są &quot;be&quot; (póki co jest dramat)!</h2>
+                <p style="text-decoration: line-through;"><em>Podobne widowisko teatralne</em> jest z użyciem czegokolwiek na czymkolwiek do obsługi przeciągania, więc póki co zdobywanie punktów i budowanie rankingów jest odłożone w bliżej nieokreślone &quot;kiedyś&quot;.</p>   
+                <p style="text-decoration: line-through;">Rozgrywka jest na czas, spróbuj osiągnąć możliwie najlepszy wynik (...zakładając, że system nie oszukuje przy przydziale punktów - ale to nie jest spisek).</p>
                 </div>
             </div>
             <div id="sterowanie">
@@ -241,7 +241,7 @@
         </div> <!--     <div id="gra">  -->
         
         
-        <footer id="stopka">&copy;2018 v0.4.16 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
+        <footer id="stopka">&copy;2018 v0.4.17 <button id="poco_button">Ale po co?</button> <button id="pomoc_button">Pomoc</button>
             <div id="poco">
                 <div class="kontener">
                     <h3>Dla Hani</h3>
@@ -249,9 +249,9 @@
                     <h3>Jaki jest cel?</h3>
                     <p>Ta strona odpowiada żywotnym potrzebom całego społeczeństwa. To jest witryna na skalę naszych możliwości. Ty wiesz, co my robimy tym serwisem? My otwieramy oczy niedowiarkom. Patrzcie, to nasze, przez nas wykonane i to nie jest nasze ostatnie słowo.</p>
                     <h3>Jeszcze raz po polskiemu</h3>
-                    <p>Poniższa witryna ma za zadanie ułatwić korzytanie z materiałów zawartych w oryginalnym serwisie żłobka. Chęć przedłużenia życia myszom oraz powierzchniom dotykowym komputerów zdecydowała o zmniejszeniu obciążenia (konkretnie z niepotrzebnego klikania kursorem w przycisk <em>powrót</em> -- [&lt;-] i kolejnego niepotrzebnego kliknięcia w kolejne zdjęcie, itd. aż do końca danej galerii przemnożone przez ilość podstron danej galerii...). Nadmiernie porysowanych ekranów w telefonach, czy tabletach też nie chemy, prawda? Nazbyt zużyty przycisk myszy lub wytarty (albo przebity) gładzik w laptopie zmusza do zakupu urządzenia wskazującego... <p>
-                    <h3>(to nie jest antyreklama pewnego sklepu komputerowego)</h3>    
-                    <p>Po prostu ten serwis zapewnia oszczędność czasu użytkownikowi, a do tego zmniejsza zużycie pasma internetowego użytkownika (pakietu transmisji danych na tzw. <em>urządzeniach mobilnych</em>) w porównaniu do przeglądania orygionalnej witryny. Do tego nie katuje serwera przy każdym dużym obrazku. Same plusy wynikają z korzystania z tej <em>nakładki</em>, zachęcam do dalszego korzystania.</p>    
+                    <p>Poniższa witryna ma za zadanie ułatwić korzytanie z materiałów zawartych w oryginalnym serwisie żłobka. Przede wszystkim wygoda, ale też chęć przedłużenia życia myszom oraz powierzchniom dotykowym komputerów zdecydowała o zmniejszeniu obciążenia (konkretnie z niepotrzebnego klikania kursorem w przycisk <em>powrót</em> -- [&lt;-] w przeglądarce www oraz powiązanego z nim kolejnego niepotrzebnego kliknięcia w kolejne zdjęcie, itd. aż do końca danej galerii, przemnożone przez ilość podstron danej galerii...). Nadmiernie porysowanych ekranów w telefonach, czy tabletach też nie chemy, prawda? Nazbyt zużyty przycisk myszy lub wytarty (albo przebity) gładzik w laptopie zmusza do zakupu urządzenia wskazującego... <p>
+                    <h3>(to nie jest antyreklama pewnego sklepu komputerowego) &plus; trochę technologicznego bełkotu</h3>    
+                    <p>Po prostu ten serwis zapewnia oszczędność czasu użytkownikowi, a do tego zmniejsza zużycie pobieranych danych (pakietu transmisji danych, istotnego na tzw. <em>urządzeniach mobilnych</em>, korzystających z sieci operatora GSM) w porównaniu do przeglądania orygionalnej witryny. Przy braku limitów na transfer też zyskujemy, bo przeglądarka szybciej pobiera tylko istotne treści (wskazane zdjęcia lub ich grupę), bez każdorazowego doczytywania obrazków (funkcji &quot;cache&quot; nie liczę). Do tego &quot;serwer&quot; tej nakładki nie katuje serwera macierzystego przy każdym podglądzie dużego obrazka oraz ponownym przejścu do kolejnego (licząc uprzedni powrót do zasobów w pamięci przeglądarki). Prawda, że same plusy wynikają z korzystania z tej <em>nakładki</em>? Zachęcam do dalszego użytkowania i testowania.</p>    
                     <h3>Informacje i zastrzeżenia</h3>
                     <p>Wszelkie prawa do materiałów (treści tekstowych i zdjęć) należą do ich właścicieli, tj. instytucji Żłobka w Chojnowie - <a href="http://zlobek.chojnow.eu" target="_blank">zlobek.chojnow.eu</a> oraz serwisu e-informator - <a href="http://e-informator.pl/" target="_blank">e-informator.pl</a>.</p>
                     <h3>Kontakt</h3>
@@ -261,13 +261,13 @@
             <div id="pomoc">
                 <div class="kontener">            
                     <h3>To tylko przeglądarka</h3>
-                    <p>Niniejszy serwis służy do łatwiejszego wyświetlania galerii z osobami skazanymi na pobyt w żłobku. Bezwzględnie jest wymagany dostęp do macierzystego serwisu www, bez niego nie pojawiają się treści tutaj.</p>
+                    <p>Niniejszy serwis służy do łatwiejszego wyświetlania galerii z osobami skazanymi na pobyt w żłobku. Bezwzględnie jest wymagane istnienie i funkcjonowanie macierzystego serwisu www, bez niego po prostu nie pojawiają się żadne treści tutaj &colon;P.</p>
                     <h3>Pożegnanie <em>kopiuj-wklej</em></h3>
-                    <p>Pierwotna funkcjonalnośc wymagała podania działającego odnośnika do serwisu zlobek.chojnow.eu, konkretnie do jednej z wielu galerii. Wiązało się to z koniecznością przekazania adresu, po uprzednim odwiedzeniu witryny żłobka i skopiowania zawartości z paska adresu. Teraz przegląd galerii odbywa się bezpośrednio na tej witrynie.</p>
+                    <p>Pierwotna funkcjonalnośc wymagała podania działającego odnośnika do serwisu zlobek.chojnow.eu, konkretnie do jednej z wielu galerii. Wiązało się to z koniecznością przekazania adresu do tutejszego formularza (wklejenia lub wpisania), po uprzednim odwiedzeniu witryny żłobka i skopiowania zawartości z paska adresu. Teraz przegląd wszystkich dostępnych galerii odbywa się bezpośrednio z tej witryny.</p>
                     <h3>Podstrony</h3>
-                    <p>Przeglądanie w galeriach ograniczających klikanie działa prawiłowo dla maksymalnie osiemnastu obrazków w galerii. Serwis ma umożliwić łatwą nawigację pomiędzy kolejnymi obrazkami.</p>
+                    <p>Wygodne przeglądanie w galeriach, ograniczających nadmiarowe klikanie działa prawidłowo dla maksymalnie osiemnastu obrazków w galerii. Serwis umożliwia łatwą nawigację pomiędzy kolejnymi obrazkami i ewentualnymi podstronami (kolejnymi grupami obrazków).</p>
                     <h3>Uwaga</h3> 
-                    <p>Witryna umożliwia oglądanie pokazu zdjęć poprzez mechanizm galerii tylko dla wskazanego żłobka, serwis nie wyświetli pokazu zdjęć dla innych adresów.</p>
+                    <p>Witryna umożliwia oglądanie pokazów zdjęć poprzez mechanizm galerii tylko dla wskazanego żłobka, serwis nie wyświetli pokazu zdjęć dla innych adresów.</p>
                     <h3>Użyte technologie - co tutaj zawarto (oczywistości i nie~)</h3> 
                     <ul>
                         <li class="tech_tak">HTML5</li>
@@ -282,7 +282,7 @@
                         <li class="tech_tak"><em>progressive&nbsp;enhancement</em></li>                        
                         <li class="tech_tak">kompatybilność</li>
                     </ul>
-                    <h3>Zgodność źródeł z konwencjami JS na poziomie 99,7% ;P</h3> 
+                    <h3>Zgodność źródeł z konwencjami JS na poziomie 98,666667% &semi;P</h3> 
                     <ul>
                         <li>WielBłąd(&nbsp;),&nbsp;a&nbsp;camelCamel()</li>
                         <li>no(n)Tacja&nbsp;{...}</li>
@@ -296,11 +296,11 @@
                         <li class="tech_nie">promesy</li>                    
                         <li class="tech_nie">Node.js</li>
                         <li class="tech_nie">SASS/LESS/PostCSS</li>
-                        <li class="tech_nie">CSS&nbsp;Grid</li>
+                        <li class="tech_nie">CSS&nbsp;grid</li>
                         <li class="tech_nie">SVG?</li>
                     </ul>
-                    <h3>Nadal na etapie projektowania</h3>
-                    <p>Status projektu nieukończony, nadal nie w <em>produkcji</em>.</p> 
+                    <h3>Status projektu</h3>
+                    <p>W zakresie głównej funkcjonalności na ukończeniu. Szlifowanie, testy i poprawki różnego kalibru jasno określają, że projekt jest nadal <em>nieukończony</em> (choć brakuje dosłownie kilku procent dla ukończenia kilku kluczowych i kosmetycznych zagadnień - głównie kompatybilność i brak niespodziewanych udziwnień). Nadal rozszerzone informowanie dla potrzeb debugowania. W obszarze dodatkowym (gra), z uwagi na &quot;przeciągające się&quot; problemy z przeciąganiem - jeszcze daleko do statusu <em>w produkcji</em>...</p> 
                 </div>
             </div>
         </footer>	

--- a/witryna.js
+++ b/witryna.js
@@ -1094,7 +1094,8 @@ var ileRazy = Math.floor( nrGalerii / 5 ) ;  // teraz niepotrzebne, choć zachow
 var ileReszty = nrGalerii % 5 ;         // teraz niepotrzebne
 var pozycjaWGalerii = KtoraPozycjaWGalerii( nrGalerii ) ;
 var nrPodstronyGalerii = ileRazy ;    // POPRAWIĆ TE WARUNKI NA OBLICZANIE GALERII DLA DANEGO NUMERU (PODSTRONA + POZYCJA)
-    if ( g_ilosc_wszystkich_galerii % 5 != 0 ) nrPodstronyGalerii = nrPodstronyGaleriiMAX - Math.floor( ( nrGalerii + pozycjaWGalerii ) / 5 ) ;   
+    // if ( g_ilosc_wszystkich_galerii % 5 != 0 )
+    nrPodstronyGalerii = nrPodstronyGaleriiMAX - Math.floor( ( nrGalerii + pozycjaWGalerii ) / 5 ) ;   
 return nrPodstronyGalerii;
 } // KtoraPodstronaWGalerii-END    
     
@@ -1508,11 +1509,11 @@ evt.preventDefault; // nie wykonuj domyślnego SUBMIT po kliknięciu
     var adresPodstrony =  '/' + 'galeria,k0,p' + podstronaWGalerii + '.html' ;    // sumowanie ciagu tekstowego
  
     // DEBUG_MODE    
-    var trescWygenerowana = "<p>ILOŚĆ_GALERII_MAX: " + g_ilosc_wszystkich_galerii + ", ILOŚĆ_PODSTRON_MAX: " + nrPodstronyGaleriiMAX + "<br />"; 
-    trescWygenerowana += "WYBRANA: " + wybranyNrGalerii + ", PODSTRONA: " + podstronaWGalerii + ", POZYCJA_W_GALERII: +" + pozycjaWGalerii + "<br />"; 
-    trescWygenerowana += "<br /> Dopasowano na " + podstronaWGalerii + ". podstronie, z przesunięciem " + pozycjaWGalerii ;
-    trescWygenerowana += ". Łączny adres to: \"" + g_adres_strony + adresPodstrony + "\"</p>";
-    $('#status_wybranej_galerii').html( trescWygenerowana );
+        /*  var trescWygenerowana = "<p>ILOŚĆ_GALERII_MAX: " + g_ilosc_wszystkich_galerii + ", ILOŚĆ_PODSTRON_MAX: " + nrPodstronyGaleriiMAX + "<br />"; 
+            trescWygenerowana += "WYBRANA: " + wybranyNrGalerii + ", PODSTRONA: " + podstronaWGalerii + ", POZYCJA_W_GALERII: +" + pozycjaWGalerii + "<br />"; 
+            trescWygenerowana += "<br /> Dopasowano na " + podstronaWGalerii + ". podstronie, z przesunięciem " + pozycjaWGalerii ;
+            trescWygenerowana += ". Łączny adres to: \"" + g_adres_strony + adresPodstrony + "\"</p>";
+            $('#status_wybranej_galerii').html( trescWygenerowana );*/
         
     $('#nazwa_galerii').addClass('szara_zawartosc');
     $( g_miejsce_na_zdjecia ).empty();

--- a/witryna.js
+++ b/witryna.js
@@ -355,7 +355,7 @@ console.log("PRZED - Dokument: " + wysokoscDokumentu + "px, Okno: " + wysokoscOk
 //PrzewinEkranDoElementu('div#skladowisko', 200, -8);  // złe miejsce, przed trteścią
 
 
-$('nav#nawigacja_galeria').html('<div class="kontener"></div>').show( 100 );     // czyszczenie kontenera na nawigację galerii, NIEZALEŻNIE czy wcześniej zawierał zawartość + jego pokazanie (gdy pierwsze wyświetlenie pierwszej podstrony)
+$('nav#nawigacja_galeria').empty().show( 100 );     // czyszczenie kontenera na nawigację galerii, NIEZALEŻNIE czy wcześniej zawierał zawartość + jego pokazanie (gdy pierwsze wyświetlenie pierwszej podstrony)
 $('#wczytywanie').hide(100);	// schowaj informację, skoro wczytano zawartość
 $('#glowna div#komentarz').hide(100);	//showaj opis-informację o ile była pokazana
 // $kontenerDocelowy.show( 100, PrzewinEkranDoElementu( kontenerDocelowyElement, 200, -8 - (wysokoscDivWczytywanie + wysokoscDivKomentarz) )  );	// pokaż kontener na zaczytaną zawartość + przewiń po wyświetleniu całości
@@ -378,7 +378,7 @@ var $listaPodstron = $( kontenerZrodlowy + ' a.link_tresc' ); // wyszukiwanie we
     if ( $listaPodstron.length >= 1 )	// czy są jakieś odnośniki do podstron/paginacji galerii?
     {					// startujemy od kolej strony po pierwszej, ale ostatni zawiera ciąg "starsze"
 
-
+    $('nav#nawigacja_galeria').append('<div class="kontener"><h3>Pozostałe podstrony wybranej galerii</h3></div>');
         
     var nazwaPodstronyGalerii = '';
 /*    var numerPodstronyDoWyswietlenia = 0;
@@ -416,7 +416,7 @@ var $listaPodstron = $( kontenerZrodlowy + ' a.link_tresc' ); // wyszukiwanie we
             id : "galeria_paginacja_" + ( i+1 ),
             class : "przycisk_galeria",
             value : nrGalerii, 
-            text : "Galeria nr " + nrGalerii,
+            text : "Podstrona nr " + nrGalerii,
             "data-tag" : g_tag_do_podmiany_zdjecia,
             "data-adres_strony" : g_adres_strony,
             "data-adres_galerii" : odnosnikPodstrony,
@@ -426,7 +426,7 @@ var $listaPodstron = $( kontenerZrodlowy + ' a.link_tresc' ); // wyszukiwanie we
         $('nav#nawigacja_galeria > div:first').append( nowyPrzycisk ); // wstawianie przycisku innego niż "poprzednia/następna" podstrona danej galerii
                 // też brak przycisku dla bieżacej galerii, np. w formie wyłączonego (nieaktywnego), bo brak takiego odnośnika teraz na www
         } // for-END
-    } // //if-END $listaPodstron.length 
+    } // //if-END $listaPodstron.length >= 1
 
 //przeszukiwanie odnośników dla miniatur w galerii, link z miniatury prowadzi do normalnej (większej) kopii obrazka
 // do galerii prowadzą odnośniki z tą klasą, do paginacji niestety też ;) | same zdjęcia i miniatury bez przypisanej klasy dla <a>

--- a/zlobek-styl.css
+++ b/zlobek-styl.css
@@ -877,8 +877,9 @@ div#glowna div#nazwa_galerii {
 background-color: deepskyblue;
 display: none;
 padding: 0.5em;
-padding-right: 1em;	
-margin-bottom: 0.5em;	
+padding-right: 1em;
+padding-bottom: 1em;
+margin-bottom: 1em;	
 overflow: hidden;	
 }
 
@@ -890,8 +891,9 @@ max-height: 320px;
 border: 4px solid white;	
 }
 
-div#glowna div#nazwa_galerii p {
+div#glowna div#nazwa_galerii p:last-child {
 font-size: 120%;
+padding-left: 0.5em;
 }
 
 div#glowna div#nazwa_galerii p.data {
@@ -1085,6 +1087,8 @@ border-radius: 10px;
 box-shadow: 2px 2px 5px rgba(0,0,0, 0.7);		
 }
 
+
+
 footer#stopka button {
 font-size: 120%;
 margin-left: 0.5em;	
@@ -1110,6 +1114,18 @@ margin: 0.5em 0;
 /* background-color: dodgerblue;	*/
 background-color: #c3d5e2;	
 background: radial-gradient(circle at top, #c3d5e2 10%, deepskyblue ); 	
+}
+
+footer#stopka h3 {
+padding: 0.6em;
+}
+
+footer#stopka p {
+font-size: 110%;    
+}
+
+footer#stopka p:last-child {
+padding-bottom: 1em;    
 }
 
 footer#stopka ul {
@@ -1668,7 +1684,7 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
 	div#spis_tresci div.kontener_odnosnik {
 	min-height: 425px;			
 	max-height: 425px;
-    width: 32%;    
+ width: 32%;    
 	}
 
 	div#spis_tresci div.kontener_odnosnik img {
@@ -1684,20 +1700,27 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
 	font-size: 90%;	
 	}
     
-    div#witryna {
-/*	margin: 0.3em auto;*/
-    width: 99.25%;      
-    }
+ div#witryna {
+ /*	margin: 0.3em auto;*/
+ width: 99.25%;      
+ }
 	
 	div#spis_tresci div.kontener_odnosnik {
 	min-height: 465px;			
 	max-height: 465px;
-    width: 24%;     
+ width: 24%;     
 	}
 
 	div#spis_tresci div.kontener_odnosnik img {
 	max-height: 240px;
-    }
+	}
+
+ div#glowna div#nazwa_galerii img {
+ margin-top: -2em;
+ }
+
+ div#glowna div#nazwa_galerii h2 {
+ padding-left: 6.5em;    /* 208px szerokośc obrazxka / 16px == 6.5 */
 }
 
 
@@ -1719,24 +1742,17 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
 	div#spis_tresci div.kontener_odnosnik {
 	min-height: 490px;			
 	max-height: 490px;
-    width: 19.1%;       
+width: 19.1%;       
 	}
 
 	div#spis_tresci div.kontener_odnosnik img {
 	max-height: 250px;
 	}
     
-    div#glowna div#nazwa_galerii img {
-    margin-top: -2.5em;
-    }
-    
-    div#glowna div#nazwa_galerii h2 {
-    padding-left: 5em;
-    }
-    
-/*    div#gra { */  /* ukrywać zdarzeniami, CSS nie schowa ponownie, jeśli pokazana  z MIN-width */
-/*    display: none;    
-    }*/
+    /* div#gra {
+    display: block;    
+    } */
+
 }
 
 @media screen and (min-width: 1300px) { 

--- a/zlobek-styl.css
+++ b/zlobek-styl.css
@@ -1,5 +1,7 @@
 @charset "utf-8";
 
+/*    --------------------------       OGÓLNE      --------------------------     */
+
 * {
 box-sizing: border-box;	
 }
@@ -7,6 +9,145 @@ box-sizing: border-box;
 body {
 font-size: 65%;	
 }
+
+input[type="button"] {
+/*background-color: darkblue; 
+color: yellow;	*/
+padding: 0.25em 1em;
+font-size: 120%;
+}
+
+button {
+padding: 0.25em 1em;
+font-size: 120%;
+}
+
+
+h1 {
+color: blueviolet;
+font-size: 220%;
+font-weight: bold;
+text-align: center;
+padding: 0.1em 0.1em;
+text-shadow: 1px 1px 1px #eee, 3px 3px 10px #666;	
+}
+
+h1.zmienny {
+transition: all 0.8s ease-out 0.1s;
+text-align: center;	
+}
+
+h1.zmienny:hover {
+margin-left: 30px;
+color: #ee6699;
+text-shadow: 1px 1px 1px #eee, 3px 3px 8px #444, 1px 1px 4px #222;
+}
+
+h1.logo {
+color: yellow;
+font-size: 300%;
+padding-bottom: 0.05em;	
+}
+
+h2 {
+font-size: 175%;
+font-weight: bold;
+/* color: darkred; */
+color: #54c;
+padding: 0.2em 0.5em;	
+text-shadow: 2px 2px 6px #666;
+text-align: center;	
+}
+
+h2.przycisk {
+background-color: dodgerblue;
+}
+
+h2.logo {
+font-size: 225%;	
+padding-top: 0;
+line-height: 20px;	
+}
+
+h3 {
+font-size: 125%;
+font-weight: bold;
+color: darkmagenta;
+text-shadow: 1px 1px 3px #ccc;
+padding: 0.2em 0.5em;	
+text-align: center;	
+}
+
+h4 {
+font-size: 115%;
+font-weight: bold;
+color: darkblue;
+text-shadow: 1px 1px 1px #ccc;
+padding: 0.2em 0.5em;	
+text-align: center;	
+}
+
+a {
+font-weight: bold;
+text-decoration-line: underline;
+text-decoration-style: solid;
+color: indigo;
+}
+    
+p {
+text-align: justify;	
+}
+
+em {
+font-style: italic;    
+}
+
+form {
+font-size: 110%;	
+}
+
+form input {
+margin: 0.2em;
+padding: 0.2em;
+font-size: 110%;		
+}
+
+p.blad {
+padding: 2em;
+margin: 3px auto;
+width: 90%;
+color: yellow;
+text-align: center;
+font-size: 2em;
+font-weight: bold;
+background-color: darkred;
+border: 2px solid #eee;
+}
+
+.clearfix::after {
+content: "";
+clear: both;
+display: table;	
+}
+
+.clearfix2 {
+clear: both;
+}
+
+.kontener {
+width : 100% ;
+max-width: 1400px;    
+align-items: center;
+margin: 0 auto;
+}
+
+.szara_zawartosc {
+filter: grayscale(80%);
+/*
+filter: brightness(120%);
+*/
+}
+
 
 div#witryna {
 margin: 0.3em auto;
@@ -16,6 +157,8 @@ overflow: hidden;
 	
 /* background: radial-gradient( ellipse, center, #222 15%, #333 100%);	*/
 }
+
+/*    --------------------------       HEADER      --------------------------    */
 
 header#naglowek {
 border-radius: 10px;    
@@ -264,17 +407,6 @@ form#wyszukaj input[type="text"] {
 width: 35em;
 }
 
-input[type="button"] {
-/*background-color: darkblue; 
-color: yellow;	*/
-padding: 0.25em 1em;
-font-size: 120%;
-}
-
-button {
-padding: 0.25em 1em;
-font-size: 120%;
-}
 	
 form#wyszukaj input[type="submit"] {
 /*background-color: darkblue; 
@@ -597,12 +729,8 @@ text-shadow: 0px 0px 10px black;
 div#spis_tresci div#selektor {
 display: none;    
 width: 99%;
-    /*background-color: crimson;*/
-
 margin: 1.5em auto;    
-    
 }
-
 
 div#spis_tresci div#selektor > div {
 display: none;
@@ -619,6 +747,7 @@ border-radius: 14px;
     border-bottom-left-radius: 14px;
     border-bottom-right-radius: 14px;*/
 border: 2px solid #eee;
+cursor: pointer;
 transition: background-color 0.5s;    
 }
 
@@ -636,6 +765,7 @@ padding-left: 0.5em;
 padding-right: 0.5em;    
 display : inline-block; /* na potrzeby odwracania - rotacji  */
 transition: transform 0.4s, padding-left 0.3s;
+cursor: pointer;    
 }
 
 h2#selektor_naglowek:hover span:hover {
@@ -829,10 +959,7 @@ div#spis_tresci div#skladowisko_status_wybranej_galerii {
     display: none;  
 }
 
-
-/* *** główny blok - zaczytywany ***  */ 
-
-
+/*    --------------------------       GŁÓWNY ZACZYTYWANY BLOK      --------------------------    */
 
 div#glowna {
 margin-top: 0.7em;	
@@ -990,6 +1117,8 @@ box-shadow: 2px 2px 4px black, 4px 4px 8px 2px rgba(0, 0, 0, 0.6);
 transform: scale(1.1);
 }
 
+/*    --------------------------       GRA      --------------------------    */
+
 div#gra {
 display: none;
 background-color: cornflowerblue;
@@ -1072,8 +1201,7 @@ border-top: 2px dotted #666;
 
 }
 
-
-
+/*    --------------------------       FOOTER      --------------------------    */
 
 footer#stopka {
 clear: both;
@@ -1086,8 +1214,6 @@ text-align: center;
 border-radius: 10px;
 box-shadow: 2px 2px 5px rgba(0,0,0, 0.7);		
 }
-
-
 
 footer#stopka button {
 font-size: 120%;
@@ -1154,133 +1280,9 @@ border: 1px solid darkred;
 background: url(grafiki/nie_ikona.png) 4px 1px no-repeat, whitesmoke;    
 }
 
-h1 {
-color: blueviolet;
-font-size: 220%;
-font-weight: bold;
-text-align: center;
-padding: 0.1em 0.1em;
-text-shadow: 1px 1px 1px #eee, 3px 3px 10px #666;	
-}
+/*    --------------------------       SUWAKI z INPUT[type=RANGE] i różnice     --------------------------    */
 
-h1.zmienny {
-transition: all 0.8s ease-out 0.1s;
-text-align: center;	
-}
-
-h1.zmienny:hover {
-margin-left: 30px;
-color: #ee6699;
-text-shadow: 1px 1px 1px #eee, 3px 3px 8px #444, 1px 1px 4px #222;
-}
-
-h1.logo {
-color: yellow;
-font-size: 300%;
-padding-bottom: 0.05em;	
-}
-
-h2 {
-font-size: 175%;
-font-weight: bold;
-/* color: darkred; */
-color: #54c;
-padding: 0.2em 0.5em;	
-text-shadow: 2px 2px 6px #666;
-text-align: center;	
-}
-
-h2.przycisk {
-background-color: dodgerblue;
-}
-
-h2.logo {
-font-size: 225%;	
-padding-top: 0;
-line-height: 20px;	
-}
-
-h3 {
-font-size: 125%;
-font-weight: bold;
-color: darkmagenta;
-text-shadow: 1px 1px 3px #ccc;
-padding: 0.2em 0.5em;	
-text-align: center;	
-}
-
-h4 {
-font-size: 115%;
-font-weight: bold;
-color: darkblue;
-text-shadow: 1px 1px 1px #ccc;
-padding: 0.2em 0.5em;	
-text-align: center;	
-}
-
-a {
-font-weight: bold;
-text-decoration-line: underline;
-text-decoration-style: solid;
-color: indigo;
-}
-    
-p {
-text-align: justify;	
-}
-
-em {
-font-style: italic;    
-}
-
-form {
-font-size: 110%;	
-}
-
-form input {
-margin: 0.2em;
-padding: 0.2em;
-font-size: 110%;		
-}
-
-p.blad {
-padding: 2em;
-margin: 3px auto;
-width: 90%;
-color: yellow;
-text-align: center;
-font-size: 2em;
-font-weight: bold;
-background-color: darkred;
-border: 2px solid #eee;
-}
-
-.clearfix::after {
-content: "";
-clear: both;
-display: table;	
-}
-
-.clearfix2 {
-clear: both;
-}
-
-.kontener {
-width : 100% ;
-max-width: 1400px;    
-align-items: center;
-margin: 0 auto;
-}
-
-.szara_zawartosc {
-filter: grayscale(80%);
-/*
-filter: brightness(120%);
-*/
-}
-
-
-
+/*    -----     OGÓLNY     -----     */
 
 input[type=range] {
     /*removes default webkit styles*/
@@ -1302,7 +1304,8 @@ input[type=range]:focus {
     outline: none;
 }
 
-    /* style przeglądarkowe dla elementów formularzy nie są ujednolicone, dlatego trzeba operować na prefiksowanych pseudoklasach :(  */
+/* style przeglądarkowe dla elementów formularzy nie są ujednolicone, dlatego trzeba operować na prefiksowanych pseudoklasach :(  */
+/*    -----     WEBKIT     -----     */
 
 input[type=range]::-webkit-slider-runnable-track {
     height: 8px;
@@ -1348,13 +1351,10 @@ input[type=range]:hover::-webkit-slider-thumb {
     width: 20px;
 /*       margin-top: -8.5px; */
         margin-bottom: -4px;
-    
    /* background-color: orange;*/
 }
 
-
-
-
+/*    -----     MOZILLA     -----     */
 
 input[type=range]::-moz-range-track {
 /*    width: 300px;*/
@@ -1369,7 +1369,7 @@ input[type=range]::-moz-range-track {
 input[type=range]:hover::-moz-range-track,
 input[type=range]:focus::-moz-range-track {
     background-color: #eee;
-    box-shadow: 0 0 2px white;    
+/*    box-shadow: 0 0 2px white; */   
 }
 
 input[type=range]::-moz-range-thumb {
@@ -1379,6 +1379,7 @@ input[type=range]::-moz-range-thumb {
     border-radius: 50%;
     background-color: yellow;
     cursor: pointer;
+        outline: none;
 }
 
 input[type=range]:focus::-moz-range-thumb {
@@ -1388,11 +1389,15 @@ input[type=range]:focus::-moz-range-thumb {
 
 /*hide the outline behind the border*/
 input[type=range]:-moz-focusring {
-  outline: 3px solid white;
-  outline-offset: 1px;
+    outline: 3px solid transparent;
+    outline-offset: 1px;        /* musi być jakis odstep, tylko dla :focus narzuca ramkę przeglądarka */
+      /*outline: 3px solid white;*/
+/*    outline-offset: 1px;*/
 }
 
+/*    -----     MICROSOFT/IE/EDGE     -----     */
     /* UWAGA: EDGE "rozumie" i przejmuje style z prefiksem "-WEBKIT" mimo, że są okreśłone później dla niego z "-MS-" (ale inne atrybuty)  */    
+
 input[type=range]::-ms-track {
 /*    width: 300px;*/
     height: 6px;
@@ -1468,10 +1473,7 @@ input[type=range]:hover::-ms-fill-upper {
     box-shadow: 0 0 2px white;    
 }
 
-
-
-
-
+/*    --------------------------       ANIMACJE     --------------------------    */
 
 /* tempklasse */
 .animacja_1 {
@@ -1480,7 +1482,7 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
 }
 
 
-/*      ---  A N I M A C J E  ---     */
+/*    -----     DEFINICE ANIMACJI     -----     */
 
 @keyframes obroty360 {
 	0% {
@@ -1612,7 +1614,7 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
 	}
 }
 
-/*      --- K W E R E N D Y ---     */
+/*    --------------------------       KWERENDY     --------------------------    */
 
 @media screen and (min-width: 320px) {
     
@@ -1624,11 +1626,9 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
     height: 330px;    
     }
 
+    /* header#naglowek div#banner #napisy {
 
-
-    header#naglowek div#banner #napisy {
-
-    }
+    }*/
 
     div#spis_tresci div.kontener_odnosnik {
     min-height: 375px;			
@@ -1646,7 +1646,6 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
     /*    footer#stopka {
     padding: 1em 0;	
     }*/
-    
 } 
 
 
@@ -1692,7 +1691,6 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
     footer#stopka {
     padding: 1em 0.2em;	
     }
-
 }
 
 
@@ -1707,7 +1705,6 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
     width: 99%;    
     }        
 
-
     div#spis_tresci div.kontener_odnosnik {
     min-height: 425px;			
     max-height: 425px;
@@ -1717,7 +1714,6 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
     div#spis_tresci div.kontener_odnosnik img {
     max-height: 230px;
     }
-	
 }
 
 
@@ -1779,7 +1775,6 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
     /* div#gra {
     display: block;    
     } */
-
 }
 
 @media screen and (min-width: 1300px) { 
@@ -1792,7 +1787,6 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
             radial-gradient( ellipse at bottom center, rgba(195, 213, 226, 0.8), rgba(100, 149, 237, 0.7));
     background: linear-gradient( to bottom, rgba(100, 149, 237, 0.7), rgba(195, 213, 226, 0.8) 95%), 
             radial-gradient( ellipse at bottom center, rgba(195, 213, 226, 0.8) 20%, rgba(100, 149, 237, 0.7));
-        
     }
     
     header#naglowek div#banner {
@@ -1810,69 +1804,6 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
     header#naglowek div#zagraj {
     display: block;
     }
-    
-}
-
-/*        KWERENDY MOBILE-LAST      */
-/* 
-@media screen and (max-width: 320px) { 
-
-	body {
-	font-size: 70%;	
-	} 
-
-	div#witryna {
-	margin: 0.4em auto; 	
-	}
-	
-	
-	form#wyszukaj input[type="text"] {
-    width: 17em;		
-    }
-	
-	div#galeria_spis div.kontener_odnosnik {
-	min-height: 375px;			
-	max-height: 375px;
-	}
-	
-	div#galeria_spis div.kontener_odnosnik img {
-	max-height: 220px;
-	}
-	
-	footer#stopka {
- padding: 1em 0;	
-	}
 }
 
 
-@media screen and (min-width: 321px) and (max-width: 480px) { 
-
-	body {
-	font-size: 80%;	
-	}
-	
-	div#witryna {
-	margin: 0.6em auto; 	
-	}
-
-	div#galeria_spis div.kontener_odnosnik {
-	min-height: 475px;			
-	max-height: 475px;		
-	}
-
-	div#galeria_spis div.kontener_odnosnik img {
-	max-height: 270px;
-	}
-	
-	
-	form#wyszukaj input[type="text"] {
-    width: 15em;		
-    }
-	
-	footer#stopka {
-    padding: 1em 0.2em;	
-    }
-
-}
-
-*/

--- a/zlobek-styl.css
+++ b/zlobek-styl.css
@@ -8,19 +8,6 @@ body {
 font-size: 65%;	
 }
 
-[draggable] {   /* jak zachowuje się dopwolny przeciągany element   */
-  -moz-user-select: none;
-  -khtml-user-select: none;
-  -webkit-user-select: none;
-  user-select: none;
-  /* Required to make elements draggable in old WebKit */
-  -khtml-user-drag: element;
-  -webkit-user-drag: element;    
-    cursor: move;
-width: auto;
-height: auto;    
-}
-
 div#witryna {
 margin: 0.3em auto;
 width: 98%;
@@ -1013,6 +1000,19 @@ border-radius: 10px;
 box-shadow: 2px 2px 5px rgba(0,0,0, 0.7);	    
 } 
 
+div#gra img[draggable] {   /* jak zachowuje się dowolny przeciągany element   */
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
+  /* Required to make elements draggable in old WebKit */
+  -khtml-user-drag: element;
+  -webkit-user-drag: element;    
+    cursor: move;
+width: auto;
+height: auto;    
+}
+
 div#gra div#sterowanie 
 {
 margin-top: 1em;    
@@ -1295,6 +1295,7 @@ input[type=range] {
     transition: all 0.3s;
     /*required for proper track sizing in FF*/
 /*    width: 300px;*/
+/*        height: auto;*/
 }
 
 input[type=range]:focus {
@@ -1345,6 +1346,9 @@ input[type=range]:hover::-webkit-slider-thumb {
     border: 1px solid #888;
     height: 20px;
     width: 20px;
+/*       margin-top: -8.5px; */
+        margin-bottom: -4px;
+    
    /* background-color: orange;*/
 }
 
@@ -1388,6 +1392,7 @@ input[type=range]:-moz-focusring {
   outline-offset: 1px;
 }
 
+    /* UWAGA: EDGE "rozumie" i przejmuje style z prefiksem "-WEBKIT" mimo, że są okreśłone później dla niego z "-MS-" (ale inne atrybuty)  */    
 input[type=range]::-ms-track {
 /*    width: 300px;*/
     height: 6px;
@@ -1402,11 +1407,14 @@ input[type=range]::-ms-track {
     /*remove default tick marks*/
     color: transparent;
     cursor: pointer;
+        margin-top: 4px;
+        margin-bottom: 4px;
 }
 
 input[type=range]::-ms-fill-lower {
 /*    background-color: darkorange;*/
-    background-color: #54c;
+    background-color: #54c; 
+/*    background-color: royalblue;     */
     border-radius: 10px;
 }
 
@@ -1423,16 +1431,34 @@ input[type=range]::-ms-thumb {
     border-radius: 50%;
     background: yellow;
     cursor: pointer;
+    margin-top: 0; /* przejmowany zły atrybut z WEBKITA */
+    margin-bottom: 0; /* ++ */
 }
 
-input[type=range]:focus::-ms-thumb {
+input[type=range]:hover::-ms-thumb
+{
     border: 2px solid yellow;
+    margin-top: -2px;     
+    margin-bottom: -2px;
+        height: 18px;
+        width: 18px;
+    
+}
+
+input[type=range]:focus::-ms-thumb
+{
+    border: 4px solid yellow;
+        height: 20px;
+        width: 20px;
+        margin-top: -2px;   
+         margin-bottom: -2px;    
 }
 
 input[type=range]:focus::-ms-fill-lower,
 input[type=range]:hover::-ms-fill-lower {
-/*    background-color: orange;*/
-    background-color: royalblue; 
+/*    background-color: orange; */
+/*    background-color: royalblue; */
+    background-color: #54c;     
     box-shadow: 0 0 4px white;    
 }
 
@@ -1589,48 +1615,49 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
 /*      --- K W E R E N D Y ---     */
 
 @media screen and (min-width: 320px) {
-	body {
-	font-size: 70%;	
-	}     
     
+    body {
+    font-size: 70%;	
+    }     
+
     header#naglowek div#banner {
     height: 330px;    
     }
-    
 
-    
+
+
     header#naglowek div#banner #napisy {
-    
+
     }
-    
+
     div#spis_tresci div.kontener_odnosnik {
-	min-height: 375px;			
-	max-height: 375px;
-	}
-	
-	div#spis_tresci div.kontener_odnosnik img {
-	max-height: 210px;
-	}
-    
+    min-height: 375px;			
+    max-height: 375px;
+    }
+
+    div#spis_tresci div.kontener_odnosnik img {
+    max-height: 210px;
+    }
+
     nav#spis_sterowanie h2#zaladuj_galerie_spis {
     max-width: 16em;
     }
-        
-/*    footer#stopka {
+
+    /*    footer#stopka {
     padding: 1em 0;	
-	}*/
+    }*/
     
 } 
 
 
 @media screen and (min-width: 470px) { 
 
-	body {
-	font-size: 80%;	
-	}
-	
-	div#witryna {
-/*	margin: 0.4em auto;*/
+    body {
+    font-size: 80%;	
+    }
+
+    div#witryna {
+    /*	margin: 0.4em auto;*/
     width: 98.5%;    
     }
 
@@ -1648,21 +1675,21 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
     max-width: 75%;
     }
     
-	div#spis_tresci div.kontener_odnosnik {
-	min-height: 415px;			
-	max-height: 415px;
+    div#spis_tresci div.kontener_odnosnik {
+    min-height: 415px;			
+    max-height: 415px;
     width: 48.2%;    
-	}
+    }
 
-	div#spis_tresci div.kontener_odnosnik img {
-	max-height: 220px;
-	}
-	
+    div#spis_tresci div.kontener_odnosnik img {
+    max-height: 220px;
+    }
+
     form#wybierz_galerie input.maly_guzik {
     display: block;
     }
-    
-	footer#stopka {
+
+    footer#stopka {
     padding: 1em 0.2em;	
     }
 
@@ -1671,84 +1698,84 @@ animation: obroty_delikatne_3 6.5s infinite ease-out;
 
 @media screen and (min-width: 700px) { 
 
-	body {
-	font-size: 85%;	
-	}
-	
-	div#witryna {
-/*	margin: 0.4em auto;*/
+    body {
+    font-size: 85%;	
+    }
+
+    div#witryna {
+    /*	margin: 0.4em auto;*/
     width: 99%;    
     }        
 
-    
-	div#spis_tresci div.kontener_odnosnik {
-	min-height: 425px;			
-	max-height: 425px;
- width: 32%;    
-	}
 
-	div#spis_tresci div.kontener_odnosnik img {
-	max-height: 230px;
-	}
+    div#spis_tresci div.kontener_odnosnik {
+    min-height: 425px;			
+    max-height: 425px;
+    width: 32%;    
+    }
+
+    div#spis_tresci div.kontener_odnosnik img {
+    max-height: 230px;
+    }
 	
 }
 
 
 @media screen and (min-width: 940px) { 
 
-	body {
-	font-size: 90%;	
-	}
-    
- div#witryna {
- /*	margin: 0.3em auto;*/
- width: 99.25%;      
- }
-	
-	div#spis_tresci div.kontener_odnosnik {
-	min-height: 465px;			
-	max-height: 465px;
- width: 24%;     
-	}
+     body {
+     font-size: 90%;	
+     }
 
-	div#spis_tresci div.kontener_odnosnik img {
-	max-height: 240px;
-	}
+     div#witryna {
+     /*	margin: 0.3em auto;*/
+     width: 99.25%;      
+     }
 
- div#glowna div#nazwa_galerii img {
- margin-top: -2em;
- }
+     div#spis_tresci div.kontener_odnosnik {
+     min-height: 465px;			
+     max-height: 465px;
+     width: 24%;     
+     }
 
- div#glowna div#nazwa_galerii h2 {
- padding-left: 6.5em;    /* 208px szerokośc obrazxka / 16px == 6.5 */
+     div#spis_tresci div.kontener_odnosnik img {
+     max-height: 240px;
+     }
+
+     div#glowna div#nazwa_galerii img {
+     margin-top: -2em;
+     }
+
+     div#glowna div#nazwa_galerii h2 {
+     padding-left: 6.5em;    /* 208px szerokośc obrazxka / 16px == 6.5 */
+    }
 }
-
 
 @media screen and (min-width: 1180px) { 
 
-	body {
-	font-size: 100%;	
-	}
-    
+    body {
+    font-size: 100%;	
+    }
+
     div#witryna {
-/*	margin: 0.2em auto;*/
+    /*	margin: 0.2em auto;*/
     width: 99.5%;    
     }
 
     header#naglowek div#banner {
     height: 170px;    
     }
-    
-	div#spis_tresci div.kontener_odnosnik {
-	min-height: 490px;			
-	max-height: 490px;
-width: 19.1%;       
-	}
 
-	div#spis_tresci div.kontener_odnosnik img {
-	max-height: 250px;
-	}
-    
+    div#spis_tresci div.kontener_odnosnik {
+    min-height: 490px;			
+    max-height: 490px;
+    width: 19.1%;       
+    }
+
+    div#spis_tresci div.kontener_odnosnik img {
+    max-height: 250px;
+    }
+
     /* div#gra {
     display: block;    
     } */


### PR DESCRIPTION
* footer texts: content added and rearranged of headings with paragraphs
* changed a condition and partially a formula to compute gallery subpage by given gallery number
* rearranged elements of current gallery on wider screens
  - added also some pading 
* verified proper showing four galleries on the row (previously was good too)
  - changed media queries treshold
* changed global '[draggable]' into game draggable 'img' elements
* moved loading notification before button load-next-gallery
  - also before the selected gallery subpage
* added a helper mouse cursor for actions on selecting gallery upper belt 
* added generic text inside subgallery navigation
* many tests inside different browsers and their subversions
  - look & behavior
* invisible CSS cleanings:
  - moved up generic declarations
  - comments like headers
* just test: labels of decrement/increment buttons
* fixed form sliders in FireFox browser (got rid of white border)
* and many more unmentioned here...

