### PR TITLE
v0.5.46 - quick fix for the closing button of the current gallery

### DIFF
--- a/_changelog.md
+++ b/_changelog.md
@@ -1,3 +1,78 @@
+v0.5.46 - quick fix for the closing button of the current gallery 
+
+* v0.5.46 -- [2020-01-21]
+
+[+] ADDED
+
+-- zlobek-styl.css
+* added "exclusive" styles for the gallery close button (item with id "current_closing_gallery")
+  - this element is based on previously set styles that another close button has
+  - here only the differences in cascading are defined (but by default the style with the entire line, like a block element - this is how the left margin was defined)
+  - but a modification was also made for the "MINIMUM 320px screen" query, which changes the behavior to flowing around on the right, but with no margin to occupy the entire horizontal line!
+
+-- witryna.js
+* defined new function "Delete Button Close for Current Gallery"
+  - it blocks pressing the 'X' button by dropping it
+  - the reaction on pressing the 'X' button inside the currently displayed gallery is difficult
+  - simply removes the "this button", but also shifts focus to the nearest element element (here the button for selecting any gallery or selecting a subpage number with a table of contents)
+  - such a two-step operation in terms of operating the clavirer (so that the "focus" status is not lost)
+
+[*] MODIFIED
+
+-- zlobek-styl.css
+* changed the margin value around the thumbnail element, for the photos from the current gallery subpage
+  - applies to the horizontal margin change from 0.5 to 0.75 [em]
+  - this unification introduces harmony in the display of elements, i.e. the same vertical and horizontal spacing relative to all elements
+  - this does not introduce any order, only that the elements will be at the same distance between them
+  - not all photos within the gallery subpage have the same dimensions, they differ not only in layout (horizontal / vertical)
+  - that's why sometimes little chaos are noticeable with different ratios, however, we have no influence on this - thumbnail images are downloaded from the server and can come from different devices (cellphone, camera ... of different configurations and ratio)
+* added "random gibberish" inside the commented content of selected CSS rules so that browsers do not directly interpret the commented attribute as DISABLED RULE! (these comments should already disappear or be replaced so far !; or it is also an error in FF)
+  - such interpretation was encountered during tests, and the commented content blocked access to updating the value of a given rule
+* slightly changed the attributes for the close button of the current gallery - item with id "#biezaca_galeria_zamykanie"
+  - moved evenly to the right and top edges of the parent, almost regardless of the screen resolution used
+
+-- witryna.js
+* the function "DostawPrzyciskZamykaniaDoBiezacejGalerii" behaves more conditionally
+  - it creates the closing item for the current gallery only if that component does not have a closing button
+  - therefore it will not create two or more adjacent buttons next to each other
+* event handling modified after pressing the close button of the currently displayed gallery subpage
+  - a new call has been added for the function "UsunPrzyciskZamykaniaDlaBiezacejGalerii" 
+  - only the order of calling functions within this event has been changed
+  - the call to the "Lock" button and "Delete" button for Closing Gallery are moved to the beginning of the operation
+* also changed the displaying of the selected gallery number
+  - modified the handling of the event of pressing the submit button with id "slider_gallery_submit"
+  - little changes inside only by modifying the order of called functions, moved the call of the "ZablokujPrzycisk" and "UsunPrzyciskZamykaniaDlaBiezacejGalerii" functions to the beginning of the request service
+* in a similar tone was changed the navigation event, which is fired inside the navigation on the subpages of the currently displayed gallery - "click" event on "elements" gallery button "inside the container "#nawigacja_galeria" (event delegation!)
+  - also moved earlier calls to certain functions inside this event have, which are responsible for additional actions (such as blocking the currently pressed button or deleting / hiding another element) 
+  - ... so moved the "ZablokujPrzycisk" and "UsunPrzyciskZamykaniaDlaBiezacejGalerii" function fires at the beginning of the event handling operations
+  - adeed function "UsunPrzyciskZamykaniaDlaBiezacejGalerii" here, so that the currently displayed button does not perform the closing action, i.e. hiding the entire detail component of the current gallery
+  - this function also removes the mentioned button, so that after having refreshed the view for the current subpage this button would be generated again
+  - if the button were hidden with an animation (introducing a delay!), there is a chance to press it before it was hidden; this showuld hide the entire component of the current gallery before updating its selected subpage ...
+  - ... this may lead to the display paradox of this component, e.g., only the subpage will be updated and it will only be displayed, after waiting for it to be read (the gallery header will be permanently hidden until the display of any gallery is called [... by pressing any item from the list / table of contents displayed above or selecting any number from the given range on request]); choosing gallery subpages would not display a description of the gallery;
+
+[F] FIXED
+
+-- witryna.js
+* see descriptions of changed functions in the "CHANGED" section of this update, it applies to functions:
+  - "DostawPrzyciskZamykaniaDoBiezacejGalerii"
+  - "submit" events on the element with the id "suwak_galerii_submit" - loading any gallery number
+  - "click" events on an element with the class "przycisk_galeria" inside the element with the id "nawigacja_galeria" - navigating the subpages of the currently displayed gallery
+* the above functions protect against calling the closing of the current gallery during other activities, i.e. loading another subpage of the gallery or updating the content of the current gallery by the selected gallery number
+  - as it turned out, there is a small chance for simultaneous or almost simultaneous calling by pressing the closing button 'X' after calling another of these actions,
+  - unfortunately in a possible scenario it is likely to hide the header of the current gallery or the entire component (element) from reading the updated content
+  - it is difficult, but nevertheless feasible, and adding animations or delays for the "'X' closing element" only increases the chance of this variant occurring
+  - that's why its fading animation was abandoned and its immediate removal from DOM structures was used
+* immediate removal of the closing element during navigation activities helps maintain the continuity of displaying the current gallery, because it is difficult to press this close button (it is impossible, for some reason there is a slight delay, but simply used old test equipment introduces this delay;))
+* the quickly disappearing button of closing the current gallery does not introduce chaos in hiding this element, which could hinder the operation of the function displaying any selected gallery number (events on the element "#suwak_galerii_submit")
+* downside are possible costly operations on the close button of the current gallery
+  - it must be deleted and recreated for each gallery or subpage displayed
+  - but we gain simplicity of use, you do not need to test the tri-state (exist | not_exist | show / hide), which would require complex verification before displaying the button
+  - verification of the element existence would be necessary before carrying out any action on this button, in each case of displaying current gallery or an operation on its subpages (or selecting any gallery number also!)  
+
+* closes: #69 - 'Duplication of the button to close the current gallery or / and parallel loading of another subpage when closing the current gallery.'
+
+---------------------------
+
 v0.5.45 - added improvements for the displayed current gallery
 
 * v0.5.45 -- [2020-01-19]

--- a/index.php
+++ b/index.php
@@ -350,7 +350,7 @@ setcookie('zlobek_zliczacz', $laczna_ilosc_wizyt, $czas_teraz + 3600 * 24 * 365 
                 <button id="pomoc_button">Pomoc &darr;</button>
                 <button id="symulacja_button" class="animacja_pulsowanie_kolorow">Symul-A(JAX)-cja</button>
             </div>
-            <h6>&copy;2018<?php echo "-" . date('Y'); ?> v0.5.45</h6>
+            <h6>&copy;2018<?php echo "-" . date('Y'); ?> v0.5.46</h6>
             <div id="poco">
                 <h2><em>Ale na co to komu?!</em> &ndash; sens projektu</h2>
                 <div class="kontener">

--- a/witryna.js
+++ b/witryna.js
@@ -1567,7 +1567,6 @@ trescHtml += '<p>';
     if ( diagnostyka ) trescHtml += diagnostyka + '<br />' ;
 trescHtml += galeria.opis + '</p></div>';    
 
-
 $('#nazwa_galerii').html( trescHtml );
 PokazBiezacaGalerie(200);
 // $('#nazwa_galerii').show(100);	    
@@ -2032,7 +2031,14 @@ $('#nawigacja_galeria').fadeOut( czasAnimacji );
 }    
 
 function DostawPrzyciskZamykaniaDoBiezacejGalerii () {
-$('#nazwa_galerii').prepend( '<div id="biezaca_galeria_zamykanie" tabindex="0">&times;</div>' );
+var $przyciskZamykania = $('#biezaca_galeria_zamykanie');
+    // wstaw element tylko gdy nie ma go jeszcze na stronie 
+    if ( $przyciskZamykania.length == 0 ) $('#nazwa_galerii').prepend( '<div id="biezaca_galeria_zamykanie" tabindex="0">&times;</div>' );
+}
+
+function UsunPrzyciskZamykaniaDlaBiezacejGalerii () {
+$('#biezaca_galeria_zamykanie').remove();   // usuń element (jeśli znaleziono)
+$('#selektor_naglowek').focus();    // IU/UX: też przenies focus na jakiś aktywny element PRZED lub ZA tym guzikiem (wybrano wariant PRZED)
 }
 
 function ZaczytajSpisGalerii () 
@@ -2845,7 +2851,13 @@ evt.preventDefault; // nie wykonuj domyślnego SUBMIT po kliknięciu
             trescWygenerowana += ". Łączny adres to: \"" + g_adres_strony + adresPodstrony + "\"</p>";
             $('#status_wybranej_galerii').html( trescWygenerowana );*/
         
-  //      if ( $('#nazwa_galerii').find('h2').text() != "" ) $('#nazwa_galerii').addClass('szara_zawartosc');  // warunkowe nadanie tymczasowej szarości dla każdej z już wyświetlonego podglądu szczegółów galerii
+    ZablokujPrzycisk( evt.target );     // blokada ewentualnego kolejnego wywołania w trakcie oczekiwnia na obsługę   
+ 
+    // PRZESUNIĘTO USUWANIE "PRZYCISKU 'X'" JAK NAJBLIŻEJ KODU OBSŁUGI ŻĄDANIA WYŚWIETLENIA WYBRANEJ GALERII 
+    UsunPrzyciskZamykaniaDlaBiezacejGalerii(); // bez tej definicji można w czasie ładowania ZAMKNĄĆ podgląd galerii, przez co nie pojawi się treść, 
+    // ..., ale widać aktywne powiadomenie o ładowaniu treści!!!
+
+    //      if ( $('#nazwa_galerii').find('h2').text() != "" ) $('#nazwa_galerii').addClass('szara_zawartosc');  // warunkowe nadanie tymczasowej szarości dla każdej z już wyświetlonego podglądu szczegółów galerii
     var zawartoscH2 = $('#nazwa_galerii').find('h2').text();    
         if ( zawartoscH2 != '' )
         {
@@ -2853,12 +2865,10 @@ evt.preventDefault; // nie wykonuj domyślnego SUBMIT po kliknięciu
         $('#nazwa_galerii').addClass('szara_zawartosc');  // warunkowe nadanie tymczasowej szarości dla każdej z już wyświetlonego podglądu szczegółów galerii ...NIE DZIAŁA w IE
         }
 
-    ZablokujPrzycisk( evt.target );     // blokada ewentualnego kolejnego wywołania w trakcie oczekiwnia na obsługę   
-        
     $( g_miejsce_na_zdjecia ).empty();
     $('nav#nawigacja_galeria').empty(); 
     // $('#wczytywanie_podstrona').show(100);  
-    PokazRamkeLadowania('podstrona');   // pokazanie ramki ładowania -- najbliższy obszar to podstrona galerii 
+    PokazRamkeLadowania('podstrona');   // pokazanie ramki ładowania -- najbliższy obszar to podstrona galerii
 
     PrzewinEkranDoElementu('div#glowna', 500, -50);  // przesunięcie do podglądu galerii, aby widzieć reakcję i postęp ładowania           
         
@@ -2925,7 +2935,14 @@ var $this = $(this);
 var serwer = g_protokol_www + $this.attr('data-adres_strony') + '/';
 var ktoraPodstrona = $this.attr('value');    
 
-//$( g_wczytywanie_podstrona ).show(100); 
+ZablokujPrzycisk( evt.target );   // blokowanie aktualnie naciśniętego przycisku do kolejnej podstrony-galeriowej; nie wymaga aktywowania, bo lista pod-galerii zostaje wygenerowana na nowno z pominięciem "aktualnego" przycisku == zawartość aktulanej podstrony galerii    
+
+    // PRZESUNIĘTO USUWANIE "PRZYCISKU 'X' "JAK NAJBLIŻEJ KODU OBSŁUGI NACISNIĘCIA DOWOLNEGO PRZYCISKU NAWIGACJI W PODGALERII
+    // ustawić jako początkową czynność blokowanie przycisku lub ukrywanie innego od zamykania (zależy na czasie!), a przetestowano możliwość wciśnięcia
+    // ...przycisku podgalerii klawiaturą, gdy kurosor myszy był nad zamykaniem podglądu bieżącej galerii!     
+UsunPrzyciskZamykaniaDlaBiezacejGalerii();   // zamiast jednokrotnie tworzyć (kiedy?), pokazywać i ukrywać, to prostsze jest kasowanie OD RAZU elementu i jego tworzenie nowo
+
+    //$( g_wczytywanie_podstrona ).show(100); 
 PokazRamkeLadowania('podstrona');   // wyświetlenie informacji o uruchomieniu wczytywania podstrony galerii - działania w tle 
 
 //alert("kliknięto '.przycisk_galeria'... albo kontener: " + this.tagName );
@@ -2939,8 +2956,6 @@ console.log('Naciśnięto wywołanie ' + ktoraPodstrona + '. podstrony danej gal
 //WczytajZewnetrznyHTMLdoTAGU( $this.attr('data-tag'), $this.attr('data-adres_strony'), $this.attr('data-adres_galerii'), $this.attr('data-elem_zewn'), "galeria_podstrona"	);
 WczytajZewnetrznyHTMLdoTAGU( $this.attr('data-tag'), serwer, $this.attr('data-adres_galerii'), $this.attr('data-elem_zewn'), "galeria_podstrona", 
                             { 'ktoraPodstrona' : ktoraPodstrona } );    // ES5, nie ES6
-
-ZablokujPrzycisk( evt.target );   // blokowanie aktualnie naciśniętego przycisku do kolejnej podstrony-galeriowej; nie wymaga aktywowania, bo lista pod-galerii zostaje wygenerowana na nowno z pominięciem "aktualnego" przycisku == zawartość aktulanej podstrony galerii    
 
 });	//  on("click")-$('#nawigacja_galeria')-END	
 	

--- a/zlobek-styl.css
+++ b/zlobek-styl.css
@@ -1339,7 +1339,7 @@ div#skladowisko a { /* po usunięciu dopełnienia ten selektor niczemu nie słu�
 }
 
 div#skladowisko a img {
-    margin: 0.75em 0.5em;
+    margin: 0.75em;
     border: 3px solid white;
     box-shadow: 2px 2px 4px black;	
     max-height: 150px;
@@ -1407,13 +1407,13 @@ div#gra div#zasady p:first-of-type {
 div#zasady #gra_zamykanie,
 div#nazwa_galerii #biezaca_galeria_zamykanie
 {
-/*    position: absolute;*/
+/*      xqfc cposition: absolute;
+        xdf  margin-top: 5px;
+        dfdf margin-right: 5px;
+        ddssfd top: 4px;
+        dqsdf right: 4px; */
     float:right;
-/*    margin-top: 5px;
-    margin-right: 5px;*/
     margin-left: 0.5em;     /* to zostaje, ale powyższe można wywalić, dzięki czemu prawie te same wymiary i położenie jak inne zamykania */
-    top: 4px;
-    right: 4px;
     padding: 0.2em;
     padding-bottom: 0.4em;
     font-weight: bolder;
@@ -1423,6 +1423,12 @@ div#nazwa_galerii #biezaca_galeria_zamykanie
     border: 1px solid #666;
     cursor: pointer;
     transition: background-color 0.5s;
+}
+
+div#nazwa_galerii #biezaca_galeria_zamykanie {
+    margin-right: -0.125em;
+    margin-left: 100%;
+    margin-bottom: 0.5em;
 }
 
 div#zasady #gra_zamykanie:hover,
@@ -2322,6 +2328,11 @@ input[type=range]:hover::-ms-fill-upper
         flex-basis: 250px;
     }
     
+    div#nazwa_galerii #biezaca_galeria_zamykanie {
+        margin-left: 0.5em;     /*  to likwiduje pełną linię dla przyciku, przec co tyy uł galerii standardowo opływa ten przycisk */
+        margin-bottom: 0;
+    }
+
     .maly_guzik {
         min-width: 130px;
             padding: 0.45em 1em;    /* przywrócenie wzorcowych dopełnień */  


### PR DESCRIPTION
* v0.5.46 -- [2020-01-21]

[+] ADDED

-- zlobek-styl.css
* added "exclusive" styles for the gallery close button (item with id "current_closing_gallery")
  - this element is based on previously set styles that another close button has
  - here only the differences in cascading are defined (but by default the style with the entire line, like a block element - this is how the left margin was defined)
  - but a modification was also made for the "MINIMUM 320px screen" query, which changes the behavior to flowing around on the right, but with no margin to occupy the entire horizontal line!

-- witryna.js
* defined new function "Delete Button Close for Current Gallery"
  - it blocks pressing the 'X' button by dropping it
  - the reaction on pressing the 'X' button inside the currently displayed gallery is difficult
  - simply removes the "this button", but also shifts focus to the nearest element element (here the button for selecting any gallery or selecting a subpage number with a table of contents)
  - such a two-step operation in terms of operating the clavirer (so that the "focus" status is not lost)

[*] MODIFIED

-- zlobek-styl.css
* changed the margin value around the thumbnail element, for the photos from the current gallery subpage
  - applies to the horizontal margin change from 0.5 to 0.75 [em]
  - this unification introduces harmony in the display of elements, i.e. the same vertical and horizontal spacing relative to all elements
  - this does not introduce any order, only that the elements will be at the same distance between them
  - not all photos within the gallery subpage have the same dimensions, they differ not only in layout (horizontal / vertical)
  - that's why sometimes little chaos are noticeable with different ratios, however, we have no influence on this - thumbnail images are downloaded from the server and can come from different devices (cellphone, camera ... of different configurations and ratio)
* added "random gibberish" inside the commented content of selected CSS rules so that browsers do not directly interpret the commented attribute as DISABLED RULE! (these comments should already disappear or be replaced so far !; or it is also an error in FF)
  - such interpretation was encountered during tests, and the commented content blocked access to updating the value of a given rule
* slightly changed the attributes for the close button of the current gallery - item with id "#biezaca_galeria_zamykanie"
  - moved evenly to the right and top edges of the parent, almost regardless of the screen resolution used

-- witryna.js
* the function "DostawPrzyciskZamykaniaDoBiezacejGalerii" behaves more conditionally
  - it creates the closing item for the current gallery only if that component does not have a closing button
  - therefore it will not create two or more adjacent buttons next to each other
* event handling modified after pressing the close button of the currently displayed gallery subpage
  - a new call has been added for the function "UsunPrzyciskZamykaniaDlaBiezacejGalerii"
  - only the order of calling functions within this event has been changed
  - the call to the "Lock" button and "Delete" button for Closing Gallery are moved to the beginning of the operation
* also changed the displaying of the selected gallery number
  - modified the handling of the event of pressing the submit button with id "slider_gallery_submit"
  - little changes inside only by modifying the order of called functions, moved the call of the "ZablokujPrzycisk" and "UsunPrzyciskZamykaniaDlaBiezacejGalerii" functions to the beginning of the request service
* in a similar tone was changed the navigation event, which is fired inside the navigation on the subpages of the currently displayed gallery - "click" event on "elements" gallery button "inside the container "#nawigacja_galeria" (event delegation!)
  - also moved earlier calls to certain functions inside this event have, which are responsible for additional actions (such as blocking the currently pressed button or deleting / hiding another element)
  - ... so moved the "ZablokujPrzycisk" and "UsunPrzyciskZamykaniaDlaBiezacejGalerii" function fires at the beginning of the event handling operations
  - adeed function "UsunPrzyciskZamykaniaDlaBiezacejGalerii" here, so that the currently displayed button does not perform the closing action, i.e. hiding the entire detail component of the current gallery
  - this function also removes the mentioned button, so that after having refreshed the view for the current subpage this button would be generated again
  - if the button were hidden with an animation (introducing a delay!), there is a chance to press it before it was hidden; this showuld hide the entire component of the current gallery before updating its selected subpage ...
  - ... this may lead to the display paradox of this component, e.g., only the subpage will be updated and it will only be displayed, after waiting for it to be read (the gallery header will be permanently hidden until the display of any gallery is called [... by pressing any item from the list / table of contents displayed above or selecting any number from the given range on request]); choosing gallery subpages would not display a description of the gallery;

[F] FIXED

-- witryna.js
* see descriptions of changed functions in the "CHANGED" section of this update, it applies to functions:
  - "DostawPrzyciskZamykaniaDoBiezacejGalerii"
  - "submit" events on the element with the id "suwak_galerii_submit" - loading any gallery number
  - "click" events on an element with the class "przycisk_galeria" inside the element with the id "nawigacja_galeria" - navigating the subpages of the currently displayed gallery
* the above functions protect against calling the closing of the current gallery during other activities, i.e. loading another subpage of the gallery or updating the content of the current gallery by the selected gallery number
  - as it turned out, there is a small chance for simultaneous or almost simultaneous calling by pressing the closing button 'X' after calling another of these actions,
  - unfortunately in a possible scenario it is likely to hide the header of the current gallery or the entire component (element) from reading the updated content
  - it is difficult, but nevertheless feasible, and adding animations or delays for the "'X' closing element" only increases the chance of this variant occurring
  - that's why its fading animation was abandoned and its immediate removal from DOM structures was used
* immediate removal of the closing element during navigation activities helps maintain the continuity of displaying the current gallery, because it is difficult to press this close button (it is impossible, for some reason there is a slight delay, but simply used old test equipment introduces this delay;))
* the quickly disappearing button of closing the current gallery does not introduce chaos in hiding this element, which could hinder the operation of the function displaying any selected gallery number (events on the element "#suwak_galerii_submit")
* downside are possible costly operations on the close button of the current gallery
  - it must be deleted and recreated for each gallery or subpage displayed
  - but we gain simplicity of use, you do not need to test the tri-state (exist | not_exist | show / hide), which would require complex verification before displaying the button
  - verification of the element existence would be necessary before carrying out any action on this button, in each case of displaying current gallery or an operation on its subpages (or selecting any gallery number also!)

* closes: #69 - 'Duplication of the button to close the current gallery or / and parallel loading of another subpage when closing the current gallery.'